### PR TITLE
added export to pdf

### DIFF
--- a/app/assets/javascripts/templates/map/toolbar_tpl.handlebars
+++ b/app/assets/javascripts/templates/map/toolbar_tpl.handlebars
@@ -22,4 +22,12 @@
       </svg>
     </button>
   </li>
+
+  <li>
+    <a href="/export?filename=export.pdf&url={{url}}" class="btn-export" title="Export to PDF">
+      <svg class="icon">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-downloads"></use>
+      </svg>
+    </a>
+  </li>
 </ul>

--- a/app/assets/javascripts/views/map/toolbar_view.js
+++ b/app/assets/javascripts/views/map/toolbar_view.js
@@ -24,7 +24,7 @@
     },
 
     render: function() {
-      this.$el.html(this.template);
+      this.$el.html(this.template({ url: location.href }));
     },
 
     _share: function() {

--- a/app/assets/stylesheets/modules/_m-map.css.scss
+++ b/app/assets/stylesheets/modules/_m-map.css.scss
@@ -24,7 +24,7 @@
 
 .leaflet-control-zoom {
   position: absolute;
-  top: rem(150px);
+  top: rem(175px);
   right: rem(10px);
   z-index: 1;
 

--- a/app/assets/stylesheets/modules/_m-toolbar.css.scss
+++ b/app/assets/stylesheets/modules/_m-toolbar.css.scss
@@ -15,9 +15,10 @@
     width: rem(30px);
     height: rem(30px);
     background-color: $bg-color-1;
+    border-bottom: 1px solid rgba(151, 151, 151, 0.3);
 
-    &.search {
-      border-bottom: 1px solid rgba(151, 151, 151, 0.3);
+    &:last-child {
+      border-bottom: 0;
     }
 
     svg {


### PR DESCRIPTION
- PDF export service has been added to the server.
- Added a link to export the map to PDF file.

To try it:
[https://www.resilienceatlas.org/webshot?filename=export.pdf&waitFor=5000&url=https://www.resilienceatlas.org/map](https://www.resilienceatlas.org/webshot?filename=export.pdf&waitFor=5000&url=https://www.resilienceatlas.org/map)