### PR TITLE
chore: Updating cancan gem and enabling activeadmin-globalize

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 **Merged pull requests:**
 
+- Fixing ActiveAdmin view for not logged in users (monkey patch which adds support for importmaps) [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
+- Replacing deprecated cancan gem with cancancan [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
+- Enabling activeadmin-globalize which is customized fork which supports Rails 7 [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
 - Removing all obsolete or deprecated FE gems and libraries [\#87](https://github.com/ConservationInternational/resilienceatlas/pull/87) ([martintomas](https://github.com/martintomas))
 - Replacing webpacker with importmaps [\#87](https://github.com/ConservationInternational/resilienceatlas/pull/87) ([martintomas](https://github.com/martintomas))
 - Update of Ruby [\#87](https://github.com/ConservationInternational/resilienceatlas/pull/87) ([martintomas](https://github.com/martintomas))

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -53,7 +53,7 @@ gem "standard"
 
 # Translations
 gem "globalize"
-# gem "activeadmin-globalize", git: "https://github.com/GeoffAbtion/activeadmin-globalize", branch: "main" # TODO: Deprecated, fix
+gem "activeadmin-globalize", git: "https://github.com/martintomas/activeadmin-globalize", branch: "main"
 
 # Ordering and Tree structure for menus
 gem "active_admin-sortable_tree"

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -28,7 +28,7 @@ gem "will_paginate"
 
 gem "ffi"
 
-gem "cancan"
+gem "cancancan"
 
 gem "addressable"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
-    cancan (1.6.10)
+    cancancan (3.4.0)
     capistrano (3.17.2)
       airbrussh (>= 1.0.0)
       i18n
@@ -576,7 +576,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   byebug
-  cancan
+  cancancan
   capistrano (~> 3.9)
   capistrano-bundler
   capistrano-npm

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/martintomas/activeadmin-globalize
+  revision: 494dc287098c11cae97d9a545b8ebde04f5543b9
+  branch: main
+  specs:
+    activeadmin-globalize (0.9.10)
+      activeadmin (>= 1.0, < 3.0)
+      globalize (>= 3.1.0, < 7.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -554,6 +563,7 @@ DEPENDENCIES
   active_admin_theme
   active_model_serializers
   activeadmin
+  activeadmin-globalize!
   activeadmin_addons
   acts_as_list
   addressable

--- a/backend/app/admin/layer_group.rb
+++ b/backend/app/admin/layer_group.rb
@@ -23,8 +23,7 @@ ActiveAdmin.register LayerGroup do
       f.has_many :agrupations, allow_destroy: true do |deg|
         deg.input :layer,
           as: :select,
-          collection: Layer.order("layer_translations.name")
-            .map { |l| ["#{l.name} - id: #{l.id}", l.id] }
+          collection: Layer.with_translations.sort_by(&:name).map { |l| ["#{l.name} - id: #{l.id}", l.id] }
         deg.input :active
       end
       f.input :site_scope
@@ -37,8 +36,7 @@ ActiveAdmin.register LayerGroup do
       f.input :layer_group_type, as: :select, collection: %w[group category subcategory subgroup]
       f.input :super_group,
         as: :select,
-        collection: LayerGroup.with_translations
-          .order("layer_group_translations.name").map { |lg| ["#{lg.name} - #{lg.id}", lg.id] }
+        collection: LayerGroup.with_translations.sort_by(&:name).map { |lg| ["#{lg.name} - #{lg.id}", lg.id] }
       # f.input :icon_class
       f.actions
     end

--- a/backend/app/assets/stylesheets/active_admin.css.scss
+++ b/backend/app/assets/stylesheets/active_admin.css.scss
@@ -8,7 +8,7 @@
 // $sidebar-width: 242px;
 
 // Active Admin's got SASS!
-// @import "active_admin/active_admin_globalize";
+@import "active_admin/active_admin_globalize";
 @import "active_admin/mixins";
 @import "active_admin/base";
 @import "trix";

--- a/backend/app/javascript/active_admin.js
+++ b/backend/app/javascript/active_admin.js
@@ -3,3 +3,4 @@
 //= require trix
 //= require utils/upload_attachement
 //= require activeadmin_addons/all
+//= require active_admin/active_admin_globalize

--- a/backend/app/javascript/application.js
+++ b/backend/app/javascript/application.js
@@ -1,8 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 
-import "trix";
-import "@rails/actiontext";
-import turbolinks from "turbolinks";
-
-turbolinks.start();
-

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -4,9 +4,8 @@ class Ability
   def initialize(admin_user)
     @admin_user = admin_user
 
-    return admin_rights if @admin_user.admin?
-    return manager_rights if @admin_user.manager?
-
+    admin_rights if @admin_user.admin?
+    manager_rights if @admin_user.manager?
     staff_rights if @admin_user.staff?
   end
 

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -1,19 +1,29 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(user)
-    user ||= User.new # guest user (not logged in)
-    case user.role
-    when "admin"
-      # superusers can do everything, no need to specify
-      can :manage, :all
-    when "manager"
-      can :read, ActiveAdmin::Page, name: "Dashboard"
-      can :manage, [LayerGroup, Category, MapMenuEntry, Model, SitePage, SiteScope, Source, User]
-      can [:create, :update, :read], [Layer]
-    when "staff"
-      can :read, ActiveAdmin::Page, name: "Dashboard"
-      can :read, [Layer, LayerGroup, Category]
-    end
+  def initialize(admin_user)
+    @admin_user = admin_user
+
+    return admin_rights if @admin_user.admin?
+    return manager_rights if @admin_user.manager?
+
+    staff_rights if @admin_user.staff?
+  end
+
+  private
+
+  def admin_rights
+    can :manage, :all
+  end
+
+  def manager_rights
+    can :read, ActiveAdmin::Page, name: "Dashboard"
+    can :manage, [LayerGroup, Category, MapMenuEntry, Model, SitePage, SiteScope, Source, User]
+    can [:create, :update, :read], [Layer]
+  end
+
+  def staff_rights
+    can :read, ActiveAdmin::Page, name: "Dashboard"
+    can :read, [Layer, LayerGroup, Category]
   end
 end

--- a/backend/app/models/layer.rb
+++ b/backend/app/models/layer.rb
@@ -102,9 +102,8 @@ class Layer < ApplicationRecord
   accepts_nested_attributes_for :sources, allow_destroy: true
 
   translates :name, :info, :legend, :title, :data_units, :processing, :description
-  # active_admin_translates :name, :info, :legend, :title, :data_units, :processing, :description
+  active_admin_translates :name, :info, :legend, :title, :data_units, :processing, :description
 
-  default_scope { with_translations(I18n.locale) }
   scope :site, ->(site) {
                  eager_load([layer_groups: :super_group])
                    .where(layer_groups: {site_scope_id: site})

--- a/backend/app/models/layer_group.rb
+++ b/backend/app/models/layer_group.rb
@@ -27,7 +27,7 @@ class LayerGroup < ApplicationRecord
   accepts_nested_attributes_for :agrupations, allow_destroy: true
 
   translates :name, :info
-  # active_admin_translates :name, :info
+  active_admin_translates :name, :info
 
   validate :avoid_recursivity, on: :update
   validate :super_group_scope

--- a/backend/app/views/layouts/active_admin_logged_out.html.erb
+++ b/backend/app/views/layouts/active_admin_logged_out.html.erb
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="<%=I18n.locale%>">
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+
+  <title><%= [@page_title, ActiveAdmin.application.site_title(self)].compact.join(" | ") %></title>
+
+  <% ActiveAdmin.application.stylesheets.each do |style, options| %>
+    <% if ActiveAdmin.application.use_webpacker %>
+      <%= stylesheet_pack_tag style, **options %>
+    <% else %>
+      <%= stylesheet_link_tag style, **options %>
+    <% end %>
+  <% end %>
+  <% ActiveAdmin.application.javascripts.each do |path| %>
+    <% if path == "active_admin.js" %>
+      <%= javascript_importmap_tags "active_admin" %>
+    <% elsif path&.match?(URI::DEFAULT_PARSER.make_regexp) %>
+      <%= javascript_include_tag path %>
+    <% end %>
+    <%# if ActiveAdmin.application.use_webpacker %>
+      <%#= javascript_pack_tag path %>
+    <%# else %>
+      <%#= javascript_include_tag path %>
+    <%# end %>
+  <% end %>
+
+  <%= favicon_link_tag ActiveAdmin.application.favicon if ActiveAdmin.application.favicon %>
+
+  <% ActiveAdmin.application.meta_tags_for_logged_out_pages.each do |name, content| %>
+    <%= tag(:meta, name: name, content: content) %>
+  <% end %>
+
+  <%= csrf_meta_tag %>
+</head>
+<body class="active_admin logged_out <%= controller.action_name %>">
+<div id="wrapper">
+
+  <div id="content_wrapper">
+    <div class="flashes">
+      <% flash_messages.each do |type, message| %>
+        <%= content_tag :div, message, class: "flash flash_#{type}" %>
+      <% end %>
+    </div>
+    <div id="active_admin_content">
+      <%= yield %>
+    </div>
+  </div>
+  <div id="footer">
+    <%= yield :footer %>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Fixing ActiveAdmin view for not logged in users (monkey patch which adds support for importmaps) [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
- Replacing deprecated cancan gem with cancancan [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
- Enabling activeadmin-globalize which is customized fork which supports Rails 7 [\#88](https://github.com/ConservationInternational/resilienceatlas/pull/88) ([martintomas](https://github.com/martintomas))
