### PR TITLE
Add more cases to the journey end-to-end test

### DIFF
--- a/.github/workflows/frontend_test.yml
+++ b/.github/workflows/frontend_test.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           REACT_APP_API_HOST: ${{ secrets.REACT_APP_API_HOST }}
           REACT_APP_API_PROD: ${{ secrets.REACT_APP_API_HOST }}
+          REACT_APP_SITE: ${{ secrets.REACT_APP_API_HOST }}
           NODE_PATH: ./src
           SASS_PATH: ./node_modules:/src/views/styles/
           CI: false

--- a/frontend/cypress/e2e/journeys-detail.cy.js
+++ b/frontend/cypress/e2e/journeys-detail.cy.js
@@ -14,16 +14,88 @@ describe('Journeys detail page', () => {
     });
   });
 
-  it('should have a title according the API response', () => {
+  it('should correspond to the API response', () => {
     cy.wait('@journeyDetailRequest').then(({ response }) => {
       cy.wrap(response.statusCode).should('be.equal', 200);
-      cy.url().should('include', `/journeys/${response.body[0].id}/step/1`);
-      cy.get('.l-journey__intro .intro > h1')
-        .first()
-        .contains(response.body[0].title, { matchCase: false });
-      cy.get('.l-journey__intro .intro > h3')
-        .first()
-        .contains(response.body[0].subtitle);
+
+      const { id, steps } = response.body[0];
+
+      steps.forEach((step, stepIndex) => {
+        cy.log(`Testing step with index ${stepIndex} and type "${step.type}"`);
+
+        cy.url().should('include', `/journeys/${id}/step/${stepIndex + 1}`);
+
+        switch (step.type) {
+          case 'landing':
+            cy.get('.l-journey__intro .intro > h1')
+              .first()
+              .contains(step.title, { matchCase: false });
+            cy.get('.l-journey__intro .intro > h3')
+              .first()
+              .contains(step.theme, { matchCase: false });
+            break;
+
+          case 'conclusion':
+            cy.get('.l-journey h2')
+              .first()
+              .contains(step.title, { matchCase: false });
+
+            if (step.subtitle) {
+              cy.get('.l-journey h3')
+                .first()
+                .contains(step.subtitle, { matchCase: false });
+            }
+
+            cy.get('.l-journey h3 + div')
+              .first()
+              .should($div => {
+                const node = document.createElement('div');
+                node.innerHTML = step.content;
+                expect($div).to.have.text(node.textContent);
+              });
+            break;
+
+          case 'chapter':
+            cy.get('.l-journey .chapter-intro h1')
+              .first()
+              .contains(step.title, { matchCase: false });
+            cy.get('.l-journey .chapter-intro p')
+              .first()
+              .contains(step.content, { matchCase: false });
+            break;
+
+          case 'embed':
+            cy.get('.l-journey .side-bar article > div')
+              .first()
+              .should($div => {
+                const node = document.createElement('div');
+                node.innerHTML = step.aside;
+                expect($div).to.have.text(node.textContent);
+              });
+            cy.get('.l-journey .btn-check-it')
+              .first()
+              .invoke('attr', 'href')
+              .should(href => {
+                const url = href.replace(new URL(href).origin, '');
+                const expectedUrl = step.btnUrl.replace(
+                  new URL(step.btnUrl, 'https://www.resilienceatlas.org/')
+                    .origin,
+                  '',
+                );
+                expect(url).to.eq(expectedUrl);
+              });
+            break;
+
+          default:
+            throw new Error(`No test for the "${step.type}" journey step`);
+        }
+
+        if (stepIndex + 1 < steps.length) {
+          cy.get('.l-journey')
+            .find('.btn-next')
+            .click();
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
This PR increase the cases of the journey end-to-end test. Now, a whole journey flow is tested.

## Testing instructions

Run Cypress.

## Tracking

[RA2-26](https://vizzuality.atlassian.net/browse/RA2-26)