### PR TITLE
RA2-106: Removing Germany and Italy from available locales

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **Merged pull requests:**
+- Removing Germany and Italy from available locales  [\#103](https://github.com/ConservationInternational/resilienceatlas/pull/103) ([martintomas](https://github.com/martintomas))
 - Adding data which recreates journeys at database based on original json files [\#100](https://github.com/ConservationInternational/resilienceatlas/pull/100) ([martintomas](https://github.com/martintomas))
 - PostgreSQL server upgrade to 15 in staging and production and updated GH workflow to match [\#99](https://github.com/ConservationInternational/resilienceatlas/pull/99) ([agnessa](https://github.com/agnessa))
 - Adding possibility to publish/unpublish journeys [\#95](https://github.com/ConservationInternational/resilienceatlas/pull/95) ([martintomas](https://github.com/martintomas))

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -47,7 +47,7 @@ gem "matrix" # needed by prawn, removed in ruby 3.1
 
 # Translations
 gem "globalize"
-gem "activeadmin-globalize", git: "https://github.com/martintomas/activeadmin-globalize", branch: "main"
+gem "activeadmin-globalize", github: "martintomas/activeadmin-globalize", branch: "main"
 
 # Ordering and Tree structure for menus
 gem "active_admin-sortable_tree"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/martintomas/activeadmin-globalize
+  remote: https://github.com/martintomas/activeadmin-globalize.git
   revision: b99217e8740692fff1b23c778e2ef6a49057deeb
   branch: main
   specs:

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -25,7 +25,7 @@ module ConservationInternational
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.autoload_paths << Rails.root.join("lib")
     config.eager_load_paths << Rails.root.join("lib")
-    config.i18n.available_locales = [:en, :it, :de, :es, :"pt-BR", :fr]
+    config.i18n.available_locales = [:en, :es, :"pt-BR", :fr]
     config.i18n.default_locale = :en
     config.i18n.fallbacks = [:en]
 


### PR DESCRIPTION
I have manually checked globalize records at Staging and Production and Germany/Italy are not used anywhere. From my point of view, these locales can be safely disabled for now ;)

## Tracking

https://vizzuality.atlassian.net/browse/RA2-106
