### PR TITLE
Replaced deprecated set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/backend_ci_cd.yml
+++ b/.github/workflows/backend_ci_cd.yml
@@ -119,9 +119,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_OUTPUT
         id: extract_branch
 
       - name: Deploy using capistrano

--- a/.github/workflows/frontend_ci_cd.yml
+++ b/.github/workflows/frontend_ci_cd.yml
@@ -158,9 +158,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch-upper;]$(echo ${GITHUB_REF#refs/heads/} | tr a-z A-Z )"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_OUTPUT
         id: extract_branch
 
       - name: Deploy using capistrano


### PR DESCRIPTION
Old command set-output will stop working by end of May

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I checked that the extract branch name step still works correctly after this change:
<img width="1021" alt="Screenshot 2023-04-03 at 10 03 01" src="https://user-images.githubusercontent.com/134055/229448994-b8ce1be7-b2f5-446d-a5eb-23dc286f81e8.png">

