### PR TITLE
RA2-154: Fixing all security todos

### DIFF
--- a/backend/app/admin/indicator.rb
+++ b/backend/app/admin/indicator.rb
@@ -23,28 +23,6 @@ ActiveAdmin.register Indicator do
     actions
   end
 
-  # FIXME: Check which way we should display the indicators
-  # As the gem active_admin-sortable_tree doesn't display
-  # a table and we have to check for incompatibilities
-
-  # index do
-  #   column :position
-  #   column :category
-  #   column :name
-  #   column :slug
-  #   column :column_name
-  #   column :operation
-  #   column :models do |indicator|
-  #     links = []
-  #     indicator.models.map do |model|
-  #       links << link_to(model.name, admin_model_path(model.id))
-  #     end
-  #     links.reduce(:+)
-  #   end
-  #
-  #   actions
-  # end
-
   form do |f|
     f.semantic_errors
 

--- a/backend/app/controllers/api/v1/photos_controller.rb
+++ b/backend/app/controllers/api/v1/photos_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class PhotosController < ApiController
-      # TODO: this API endpoint should be available only to Admin (session check)
+      before_action :authenticate_admin_user!
 
       def create
         @photo = Photo.new(photo_params)

--- a/backend/app/models/pdf_file.rb
+++ b/backend/app/models/pdf_file.rb
@@ -7,7 +7,6 @@ class PdfFile
     @site_name = site_name
   end
 
-  # rubocop:disable Security/Eval
   def generate_pdf_file
     Prawn::Document.generate(@pdf_file_path) do |pdf|
       # header
@@ -47,13 +46,13 @@ class PdfFile
         pdf.move_down(5)
         pdf.font_size 8
         pdf.text "Info: #{begin
-          eval(@layer["info"])[:description] # TODO: serious security risk!!!
+          JSON.parse(@layer["info"]).with_indifferent_access[:description]
         rescue
           @layer["info"]
         end}"
         pdf.move_down(5)
         pdf.text "Source: #{begin
-          eval(@layer["info"])[:source] # TODO: serious security risk!!!
+          JSON.parse(@layer["info"]).with_indifferent_access[:source]
         rescue
           @layer["info"]
         end}"
@@ -79,7 +78,6 @@ class PdfFile
       end
     end
   end
-  # rubocop:enable Security/Eval
 
   def generated_table_header(logo)
     image_file = Rails.root.join("app/assets/images/#{logo}")

--- a/backend/spec/requests/api/v1/photos_spec.rb
+++ b/backend/spec/requests/api/v1/photos_spec.rb
@@ -1,11 +1,14 @@
 require "swagger_helper"
 
 RSpec.describe "API V1 Registration", type: :request do
+  let(:admin_user) { create :admin_user }
+
   path "/api/photos" do
     post "Save new image" do
       tags "Photo"
       consumes "multipart/form-data"
       produces "application/json"
+      security [cookie_auth: []]
       parameter name: "photo[image]",
         in: :formData,
         description: "Binary data of image",
@@ -19,13 +22,23 @@ RSpec.describe "API V1 Registration", type: :request do
           }
         }
 
+      let("photo[image]") { fixture_file_upload("picture.jpg") }
+
       response "201", :success do
-        let("photo[image]") { fixture_file_upload("picture.jpg") }
+        before { sign_in admin_user }
 
         run_test!
 
         it "matches snapshot", generate_swagger_example: true do
           expect(response.body).to match_snapshot("api/v1/create_photo")
+        end
+      end
+
+      response "401", "Authentication failed" do
+        run_test!
+
+        it "returns correct error", generate_swagger_example: true do
+          expect(response_json["error"]).to eq("You need to sign in or sign up before continuing.")
         end
       end
     end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -19,6 +19,11 @@ RSpec.configure do |config|
       paths: {},
       components: {
         securitySchemes: {
+          cookie_auth: {
+            type: :apiKey,
+            name: "_backend_session",
+            in: :cookie
+          },
           tokenAuth: {
             type: :http,
             scheme: :bearer,

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -60,8 +60,8 @@ paths:
                   interactivity: molestiae
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.376+01:00'
-                  updated_at: '2023-03-15T13:03:56.376+01:00'
+                  created_at: '2023-03-28T10:36:45.130+02:00'
+                  updated_at: '2023-03-28T10:36:45.130+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -104,8 +104,8 @@ paths:
                   interactivity: cum
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.370+01:00'
-                  updated_at: '2023-03-15T13:03:56.370+01:00'
+                  created_at: '2023-03-28T10:36:45.120+02:00'
+                  updated_at: '2023-03-28T10:36:45.120+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -148,8 +148,8 @@ paths:
                   interactivity: voluptatem
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.364+01:00'
-                  updated_at: '2023-03-15T13:03:56.364+01:00'
+                  created_at: '2023-03-28T10:36:45.109+02:00'
+                  updated_at: '2023-03-28T10:36:45.109+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -221,8 +221,8 @@ paths:
                   interactivity: voluptatem
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.436+01:00'
-                  updated_at: '2023-03-15T13:03:56.436+01:00'
+                  created_at: '2023-03-28T10:36:45.235+02:00'
+                  updated_at: '2023-03-28T10:36:45.235+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -305,8 +305,8 @@ paths:
                   interactivity: voluptatem
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.546+01:00'
-                  updated_at: '2023-03-15T13:03:56.546+01:00'
+                  created_at: '2023-03-28T10:36:45.463+02:00'
+                  updated_at: '2023-03-28T10:36:45.463+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -385,8 +385,8 @@ paths:
                   interactivity: voluptatem
                   opacity:
                   query:
-                  created_at: '2023-03-15T13:03:56.694+01:00'
-                  updated_at: '2023-03-15T13:03:56.694+01:00'
+                  created_at: '2023-03-28T10:36:45.644+02:00'
+                  updated_at: '2023-03-28T10:36:45.644+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -429,7 +429,7 @@ paths:
           content:
             application/json:
               example:
-                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2Nzg5NjgyMzZ9.PqeseLiiDWiC6c8o2iULlM-fEZ2VcUmdonjNzaGnXwo
+                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2ODAwNzkwMDV9.ds9ZiuMesJsnvQ3MzJkCvihXMnMVdipzmwp2sHlZZYo
         '401':
           description: Unauthorized
           content:
@@ -612,65 +612,65 @@ paths:
             application/json:
               example:
                 data:
-                - id: '324'
+                - id: '4'
                   type: journeys
                   attributes:
                     title: Enim repellat pariatur est.
                     subtitle: Enim repellat pariatur est.
                     theme: Enim repellat pariatur est.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3745b1fded8936d37214a89223d325c4290b185a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3745b1fded8936d37214a89223d325c4290b185a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3745b1fded8936d37214a89223d325c4290b185a/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/picture.jpg
                     credits: Enim repellat pariatur est.
                     credits_url: http://kutch-spencer.com/moises
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '727'
+                      - id: '7'
                         type: journey_steps
-                      - id: '728'
+                      - id: '8'
                         type: journey_steps
-                - id: '325'
+                - id: '5'
                   type: journeys
                   attributes:
                     title: Placeat commodi libero et.
                     subtitle: Placeat commodi libero et.
                     theme: Placeat commodi libero et.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbklFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--05460de1db8a52e4d4e34598a368b14b6c3dc0d6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbklFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--05460de1db8a52e4d4e34598a368b14b6c3dc0d6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbklFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--05460de1db8a52e4d4e34598a368b14b6c3dc0d6/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/picture.jpg
                     credits: Placeat commodi libero et.
                     credits_url: http://bartoletti.com/jeremiah_cronin
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '729'
+                      - id: '9'
                         type: journey_steps
-                      - id: '730'
+                      - id: '10'
                         type: journey_steps
-                - id: '326'
+                - id: '6'
                   type: journeys
                   attributes:
                     title: Et quaerat omnis veniam.
                     subtitle: Et quaerat omnis veniam.
                     theme: Et quaerat omnis veniam.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBblVFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b75289ce42c963b7ed2e51834c12979c16132241/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBblVFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b75289ce42c963b7ed2e51834c12979c16132241/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBblVFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b75289ce42c963b7ed2e51834c12979c16132241/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/picture.jpg
                     credits: Et quaerat omnis veniam.
                     credits_url: http://hane.com/jules
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '731'
+                      - id: '12'
                         type: journey_steps
-                      - id: '732'
+                      - id: '11'
                         type: journey_steps
                 meta:
                   total: 3
@@ -709,45 +709,32 @@ paths:
             application/json:
               example:
                 data:
-                  id: '345'
+                  id: '25'
                   type: journeys
                   attributes:
                     title: Autem et et ex.
                     subtitle: Autem et et ex.
                     theme: Autem et et ex.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBclFFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c5880e20c33898e9db9f22800829709f90e30bb1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBclFFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c5880e20c33898e9db9f22800829709f90e30bb1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBclFFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c5880e20c33898e9db9f22800829709f90e30bb1/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/picture.jpg
                     credits: Autem et et ex.
                     credits_url: http://jacobson.biz/everett
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '767'
+                      - id: '50'
                         type: journey_steps
-                      - id: '770'
+                      - id: '47'
                         type: journey_steps
-                      - id: '773'
+                      - id: '56'
                         type: journey_steps
-                      - id: '776'
+                      - id: '53'
                         type: journey_steps
                 included:
-                - id: '767'
-                  type: journey_steps
-                  attributes:
-                    step_type: landing
-                    position: 25
-                    title: Et quaerat omnis veniam.
-                    description: Et quaerat omnis veniam.
-                    credits: Et quaerat omnis veniam.
-                    credits_url: http://hane.com/jules
-                    background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcWNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3cd33b794d277bb028e99995be8985c734744a01/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcWNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3cd33b794d277bb028e99995be8985c734744a01/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcWNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3cd33b794d277bb028e99995be8985c734744a01/picture.jpg
-                - id: '770'
+                - id: '50'
                   type: journey_steps
                   attributes:
                     step_type: conclusion
@@ -760,10 +747,36 @@ paths:
                     credits_url: http://keebler.info/daine
                     background_color: "#c2e0e0"
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcXNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--7246cad1f51f8466aaaf6e26d0b831cac76981a3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcXNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--7246cad1f51f8466aaaf6e26d0b831cac76981a3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcXNFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--7246cad1f51f8466aaaf6e26d0b831cac76981a3/picture.jpg
-                - id: '773'
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/picture.jpg
+                - id: '47'
+                  type: journey_steps
+                  attributes:
+                    step_type: landing
+                    position: 25
+                    title: Et quaerat omnis veniam.
+                    description: Et quaerat omnis veniam.
+                    credits: Et quaerat omnis veniam.
+                    credits_url: http://hane.com/jules
+                    background_image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/picture.jpg
+                - id: '56'
+                  type: journey_steps
+                  attributes:
+                    step_type: embed
+                    position: 76
+                    title: Eum consequuntur adipisci non.
+                    subtitle: Eum consequuntur adipisci non.
+                    content: Eum consequuntur adipisci. Facere iure beatae. In odio
+                      reiciendis.
+                    source: Eum consequuntur adipisci non.
+                    mask_sql: Eum consequuntur adipisci non.
+                    map_url: http://lind.name/alana
+                    embedded_map_url: http://lind.name/alana
+                - id: '53'
                   type: journey_steps
                   attributes:
                     step_type: chapter
@@ -774,20 +787,9 @@ paths:
                     credits: Impedit animi eveniet numquam.
                     credits_url: http://ritchie.com/jame
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f42db599d532ff40ee6364af02010c8609a61b1b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f42db599d532ff40ee6364af02010c8609a61b1b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcThFIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f42db599d532ff40ee6364af02010c8609a61b1b/picture.jpg
-                - id: '776'
-                  type: journey_steps
-                  attributes:
-                    step_type: embed
-                    position: 76
-                    content: Eum consequuntur adipisci. Facere iure beatae. In odio
-                      reiciendis.
-                    source: Eum consequuntur adipisci non.
-                    mask_sql: Eum consequuntur adipisci non.
-                    map_url: http://lind.name/alana
-                    embedded_map_url: http://lind.name/alana
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/picture.jpg
   "/api/layer-groups":
     get:
       summary: Get list of layer groups
@@ -1273,6 +1275,8 @@ paths:
       summary: Save new image
       tags:
       - Photo
+      security:
+      - cookie_auth: []
       parameters: []
       responses:
         '201':
@@ -1280,12 +1284,18 @@ paths:
           content:
             application/json:
               example:
-                id: 2
-                image_data: '{"id":"5e44c00559f4aae9bbba3829d53b3616.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
-                created_at: '2023-03-15T13:04:23.406+01:00'
-                updated_at: '2023-03-15T13:04:23.412+01:00'
-                url: "/uploads/store/5e44c00559f4aae9bbba3829d53b3616.jpg"
-                image_url: "/uploads/store/5e44c00559f4aae9bbba3829d53b3616.jpg"
+                id: 6
+                image_data: '{"id":"6649db9d696c3a2ec7061d7e257712b9.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
+                created_at: '2023-03-28T10:37:14.253+02:00'
+                updated_at: '2023-03-28T10:37:14.258+02:00'
+                url: "/uploads/store/6649db9d696c3a2ec7061d7e257712b9.jpg"
+                image_url: "/uploads/store/6649db9d696c3a2ec7061d7e257712b9.jpg"
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              example:
+                error: You need to sign in or sign up before continuing.
   "/users/register":
     post:
       summary: Register new user
@@ -1385,7 +1395,7 @@ paths:
           content:
             application/json:
               example:
-                uid: f3f1245d0c9bf08b4cb8
+                uid: e717ef237978dcecd56a
   "/api/sites":
     get:
       summary: Get list of all site scopes
@@ -1509,8 +1519,8 @@ paths:
               example:
                 id: 7
                 email: person-1@example.com
-                created_at: '2023-03-15T13:04:23.732+01:00'
-                updated_at: '2023-03-15T13:04:23.732+01:00'
+                created_at: '2023-03-28T10:37:14.610+02:00'
+                updated_at: '2023-03-28T10:37:14.610+02:00'
                 first_name: Dawna
                 last_name: Block
                 phone: "(995) 001-7692 x452"
@@ -1541,8 +1551,8 @@ paths:
                 last_name: Kowalski
                 email: jankowalski@example.com
                 id: 9
-                created_at: '2023-03-15T13:04:23.782+01:00'
-                updated_at: '2023-03-15T13:04:23.797+01:00'
+                created_at: '2023-03-28T10:37:14.662+02:00'
+                updated_at: '2023-03-28T10:37:14.677+02:00'
                 phone: "(995) 001-7692 x452"
                 organization: voluptatem
                 organization_role: voluptatem
@@ -1583,6 +1593,10 @@ paths:
                 - user
 components:
   securitySchemes:
+    cookie_auth:
+      type: apiKey
+      name: _backend_session
+      in: cookie
     tokenAuth:
       type: http
       scheme: bearer


### PR DESCRIPTION
At the past, I have put into code three `TODO` notes related to some security issues which I have seen. This PR tries to fix them all:
 - wysiwyg editor can be used only at Admin, therefore new photos (images) can be uploaded only by AdminUser --> I am adding restriction to API endpoint. Data are saved locally on server so it would be quite easy to use this endpoint to upload A LOT of data for unauthenticated user. 
 - replacing `eval(@layer["info"])` with `JSON.parse(@layer["info"]).with_indifferent_access` at two different places

## Tracking

https://vizzuality.atlassian.net/browse/RA2-154
