### PR TITLE
setting up the production server for client app

### DIFF
--- a/frontend/config/deploy/production.rb
+++ b/frontend/config/deploy/production.rb
@@ -1,10 +1,4 @@
-server '52.54.50.38', user: 'ubuntu', roles: %w{web app db}, primary: true
+server 'app.resilienceatlas.org', user: 'ubuntu', roles: %w[web app db], primary: true
 
-set :ssh_options, {
-  forward_agent: true,
-  auth_methods: %w(publickey)
-}
-
-set :rvm_custom_path, '/home/ubuntu/.rvm'
 set :node_env, 'production'
 set :branch, 'master'

--- a/frontend/src/state/utils/api.ts
+++ b/frontend/src/state/utils/api.ts
@@ -8,8 +8,6 @@ import { merge } from 'utilities/helpers';
 export const isProd = process.env.NODE_ENV === 'production';
 
 export const PORT = process.env.NEXT_PUBLIC_API_HOST;
-// uncomment this line to see map layers quickly for local testing
-// export const PORT = 'https://staging.resilienceatlas.org';
 
 const defaultConfig = {
   baseURL: `${PORT}/api`,

--- a/frontend/src/utilities/getSubdomain.ts
+++ b/frontend/src/utilities/getSubdomain.ts
@@ -1,4 +1,4 @@
-import { PORT, isProd } from '../state/utils/api';
+import { isProd } from '../state/utils/api';
 import { getRouterParam } from './routeParams';
 
 export const getSubdomainFromURL = (url: string): string => {
@@ -19,7 +19,7 @@ export const getSubdomain = (): string => {
   const siteScope = getRouterParam('site_scope');
   if (siteScope && !isProd) return siteScope;
   // Site scope depends on the domain set in the API
-  const subdomain = getSubdomainFromURL(PORT);
+  const subdomain = getSubdomainFromURL(window.location.hostname);
   return subdomain;
 };
 


### PR DESCRIPTION
Preparing the production server for deployment

- [x] Update Capistrano configuration for production
- [x] Create the project folder and shared files in the production server
- [x] Install Node v18.15.0 in the production server
- [x] `cap production deploy` should work
- [x] Update Nginx configuration
- [ ] Cleanup the server and remove the old instance
- [x] Before merging, change the branch name in `config/deploy/production.rb`