### PR TITLE
Add robots tag to prevent indexing

### DIFF
--- a/frontend/src/types/journeys.d.ts
+++ b/frontend/src/types/journeys.d.ts
@@ -5,6 +5,7 @@ export interface JourneyItem {
   type: string;
   attributes: Attributes;
   relationships: Relationships;
+  steps: JourneySteps;
 }
 
 export interface Attributes {
@@ -24,47 +25,21 @@ export interface BackgroundImage {
 }
 
 export interface Relationships {
-  journey_steps: JourneySteps;
+  journey_steps: { data: JourneyRelationship[] };
 }
 
-export type JourneySteps = Included[];
-
-export interface Datum {
-  id: string;
+export interface JourneyRelationship {
+  id: number;
   type: Type;
 }
+
+export type JourneySteps = Step[];
 
 export enum Type {
   JourneySteps = 'journey_steps',
 }
 
-export interface Journey {
-  data: Data;
-  included: Included[];
-}
-
-export type JourneyDetail = Journey & {
-  steps: JourneySteps;
-};
-
-export interface Data {
-  id: string;
-  type: string;
-  attributes: DataAttributes;
-  relationships: Relationships;
-}
-
-export interface DataAttributes {
-  title: string;
-  subtitle: string;
-  theme: string;
-  background_image: BackgroundImage;
-  credits: string;
-  credits_url: string;
-  published: boolean;
-}
-
-export interface Included {
+export interface Step {
   id: string;
   type: string;
   attributes: JourneyAttributes;

--- a/frontend/src/views/components/Journey/Journey.component.tsx
+++ b/frontend/src/views/components/Journey/Journey.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-
+import Head from 'next/head';
 // Components
 import Loader from 'views/shared/Loader';
 
@@ -12,7 +12,7 @@ import Chapter from './Chapter';
 import type { FC } from 'react';
 import type { WithRouterProps } from 'next/dist/client/with-router';
 import type { JourneyDetail as StaticJourneyDetail } from 'types/static-journeys';
-import type { JourneyDetail } from 'types/journeys';
+import type { JourneyItem } from 'types/journeys';
 
 type StaticJourneyProps = WithRouterProps & {
   // Actions
@@ -39,7 +39,7 @@ type JourneyProps = WithRouterProps & {
   journeysLength: number;
   journeyLoaded: boolean;
   journeyLoading: boolean;
-  journey: JourneyDetail;
+  journey: JourneyItem;
 };
 
 const JOURNEY_TYPES = {
@@ -103,9 +103,9 @@ const Journey: FC<JourneyProps> = ({
   useEffect(() => {
     if (!journeyLoaded && currentJourney) loadJourney(currentJourney);
   }, [currentJourney, journeyLoaded, loadJourney]);
-
-  const { steps } = journey;
   const stepIndex = Number(step) - 1;
+  const { steps, attributes: journeyAttributes } = journey;
+  const { published } = journeyAttributes || {};
 
   if (!journeyLoaded || !journey || !steps[stepIndex]) return null;
   const stepInfo = steps[stepIndex];
@@ -113,21 +113,28 @@ const Journey: FC<JourneyProps> = ({
   const { attributes } = stepInfo;
   const { step_type: stepType } = attributes;
   return (
-    <div className="l-journey" id="journeyIndexView">
-      <Loader loading={journeyLoading} />
+    <>
+      <Head>
+        {published === false && (
+          <meta name="robots" content="noindex, nofollow, noimageindex, noarchive" />
+        )}
+      </Head>
+      <div className="l-journey" id="journeyIndexView">
+        <Loader loading={journeyLoading} />
 
-      {journeyLoaded && React.createElement(JOURNEY_TYPES[stepType], { ...attributes })}
+        {journeyLoaded && React.createElement(JOURNEY_TYPES[stepType], { ...attributes })}
 
-      <Controls journeysLength={journeysLength} slideslength={steps.length} />
+        <Controls journeysLength={journeysLength} slideslength={steps.length} />
 
-      {!journeyLoading && stepType !== 'embed' && (
-        <p className={`credits ${stepType}`}>
-          <a target="_blank" rel="noopener noreferrer" href={attributes.credits_url}>
-            {attributes.credits}
-          </a>
-        </p>
-      )}
-    </div>
+        {!journeyLoading && stepType !== 'embed' && (
+          <p className={`credits ${stepType}`}>
+            <a target="_blank" rel="noopener noreferrer" href={attributes.credits_url}>
+              {attributes.credits}
+            </a>
+          </p>
+        )}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Prevent unpublished journeys from being indexed

WARNING: Merge after https://github.com/ConservationInternational/resilienceatlas/pull/122

This is a solution we want to try before testing some more complex ones like createing a server side tag or updating the robots.txt every time we update the journeys.

When the journey is not published a meta robots tag will be added to the page preventing the indexing

## Testing instructions

Go to a non indexed journey (id: 8) see that the robots tag is there.
I havent made any tests there won't be any permanent unpublished journey

## Tracking

https://vizzuality.atlassian.net/browse/RA2-59?atlOrigin=eyJpIjoiMTk4NWJiMGQyOTE2NDhjMmE2OTA4MDc0ZTZkMmE5MGQiLCJwIjoiaiJ9