### PR TITLE
RA2-25: Homepages (BE part)

### DIFF
--- a/backend/app/admin/homepage.rb
+++ b/backend/app/admin/homepage.rb
@@ -1,0 +1,74 @@
+ActiveAdmin.register Homepage do
+  includes :translations, site_scope: :translations
+
+  permit_params :site_scope_id, :credits_url, :background_image, :show_journeys,
+    translations_attributes: [:id, :locale, :title, :subtitle, :credits, :_destroy],
+    homepage_journey_attributes: [:id, :position, :_destroy, translations_attributes: [:id, :locale, :title, :_destroy]],
+    homepage_sections_attributes: [:id, :button_url, :image, :image_position, :image_credits_url, :background_color, :position, :_destroy,
+      translations_attributes: [:id, :locale, :title, :subtitle, :button_text, :image_credits, :_destroy]]
+
+  config.filters = false
+
+  controller do
+    before_save do |resource|
+      resource.homepage_journey = nil if params[:homepage][:show_journeys] == "0"
+    end
+  end
+
+  index do
+    id_column
+    column :title
+    column :subtitle
+    column :site_scope
+    column :show_journeys
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :title
+      row :subtitle
+      row :site_scope
+      row :background_image do |record|
+        render "admin/shared/preview", blob: record.background_image if record.background_image.present?
+      end
+      row :credits
+      row :credits_url
+    end
+
+    if homepage.show_journeys
+      panel "Journeys" do
+        attributes_table_for resource.homepage_journey do
+          row :id
+          row :title
+          row :position
+        end
+      end
+    end
+
+    panel "Sections" do
+      resource.homepage_sections.order(:position).each do |homepage_section|
+        attributes_table_for homepage_section do
+          row :id
+          row :title
+          row :subtitle
+          row :button_text
+          row :button_url
+          row :image do |record|
+            render "admin/shared/preview", blob: record.image if record.image.present?
+          end
+          row :image_position
+          row :image_credits
+          row :image_credits_url
+          row :background_color do |record|
+            render "admin/shared/color", color: record.background_color if record.background_color.present?
+          end
+          row :position
+        end
+      end
+    end
+  end
+
+  form partial: "form"
+end

--- a/backend/app/assets/stylesheets/admin/has_many_collapsable.css.scss
+++ b/backend/app/assets/stylesheets/admin/has_many_collapsable.css.scss
@@ -15,6 +15,10 @@ form .has-many-collapsed {
         li label {
           margin-left: 5px;
         }
+
+        .select2-container {
+          width: 75% !important;
+        }
       }
 
       trix-toolbar {

--- a/backend/app/controllers/api/v1/homepages_controller.rb
+++ b/backend/app/controllers/api/v1/homepages_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class HomepagesController < ApiController
+      include SitesFilters
+
+      def show
+        homepage = Homepage.find_by! site_scope_id: params[:site_scope]
+        render json: homepage, include: [:homepage_journey, :homepage_sections]
+      end
+    end
+  end
+end

--- a/backend/app/models/homepage.rb
+++ b/backend/app/models/homepage.rb
@@ -1,4 +1,22 @@
+# == Schema Information
+#
+# Table name: homepages
+#
+#  id                :bigint           not null, primary key
+#  credits_url       :string
+#  position          :integer          default(1), not null
+#  show_journeys     :boolean          default(FALSE), not null
+#  journeys_position :integer          default(0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  subtitle          :string
+#  credits           :string
+#  journeys_title    :string
+#
 class Homepage < ApplicationRecord
+  has_many :homepage_sections, dependent: :destroy
+
   has_one_attached :background_image, service: :local_public
 
   translates :title, :subtitle, :credits, :journeys_title, touch: true, fallbacks_for_empty_translations: true

--- a/backend/app/models/homepage.rb
+++ b/backend/app/models/homepage.rb
@@ -1,0 +1,19 @@
+class Homepage < ApplicationRecord
+  has_one_attached :background_image, service: :local_public
+
+  translates :title, :subtitle, :credits, :journeys_title, touch: true, fallbacks_for_empty_translations: true
+  active_admin_translates :title, :subtitle, :credits, :journeys_title
+
+  translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+  translation_class.validates_presence_of :subtitle, if: -> { locale.to_s == I18n.default_locale.to_s }
+  translation_class.validates_presence_of :journeys_title, if: -> {
+    globalized_model.show_journeys && locale.to_s == I18n.default_locale.to_s
+  }
+
+  validates_presence_of :journeys_position, if: -> { show_journeys }
+  validates :position, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :journeys_position, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :show_journeys, inclusion: { in: [true, false] }
+  validates :background_image, presence: true, content_type: /\Aimage\/.*\z/
+  validates :credits_url, url: true
+end

--- a/backend/app/models/homepage.rb
+++ b/backend/app/models/homepage.rb
@@ -2,36 +2,38 @@
 #
 # Table name: homepages
 #
-#  id                :bigint           not null, primary key
-#  credits_url       :string
-#  position          :integer          default(1), not null
-#  show_journeys     :boolean          default(FALSE), not null
-#  journeys_position :integer          default(0), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  title             :string
-#  subtitle          :string
-#  credits           :string
-#  journeys_title    :string
+#  id                  :bigint           not null, primary key
+#  homepage_journey_id :bigint
+#  site_scope_id       :bigint           not null
+#  credits_url         :string
+#  show_journeys       :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  title               :string
+#  subtitle            :string
+#  credits             :string
 #
 class Homepage < ApplicationRecord
+  belongs_to :site_scope
+  belongs_to :homepage_journey, optional: true, dependent: :destroy
+
   has_many :homepage_sections, dependent: :destroy
 
   has_one_attached :background_image, service: :local_public
 
-  translates :title, :subtitle, :credits, :journeys_title, touch: true, fallbacks_for_empty_translations: true
-  active_admin_translates :title, :subtitle, :credits, :journeys_title
+  translates :title, :subtitle, :credits, touch: true, fallbacks_for_empty_translations: true
+  active_admin_translates :title, :subtitle, :credits
 
   translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
   translation_class.validates_presence_of :subtitle, if: -> { locale.to_s == I18n.default_locale.to_s }
-  translation_class.validates_presence_of :journeys_title, if: -> {
-    globalized_model.show_journeys && locale.to_s == I18n.default_locale.to_s
-  }
 
-  validates_presence_of :journeys_position, if: -> { show_journeys }
-  validates :position, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :journeys_position, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :show_journeys, inclusion: { in: [true, false] }
+  validates_presence_of :homepage_journey, if: -> { show_journeys }
+  validates_uniqueness_of :site_scope_id
+
+  validates :show_journeys, inclusion: {in: [true, false]}
   validates :background_image, presence: true, content_type: /\Aimage\/.*\z/
   validates :credits_url, url: true
+
+  accepts_nested_attributes_for :homepage_journey, allow_destroy: true
+  accepts_nested_attributes_for :homepage_sections, allow_destroy: true
 end

--- a/backend/app/models/homepage_journey.rb
+++ b/backend/app/models/homepage_journey.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: homepage_journeys
+#
+#  id         :bigint           not null, primary key
+#  position   :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  title      :string
+#
+class HomepageJourney < ApplicationRecord
+  has_one :homepage, dependent: :nullify
+
+  translates :title, touch: true, fallbacks_for_empty_translations: true
+  active_admin_translates :title
+
+  translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+
+  validates :position, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+end

--- a/backend/app/models/homepage_section.rb
+++ b/backend/app/models/homepage_section.rb
@@ -31,7 +31,7 @@ class HomepageSection < ApplicationRecord
 
   validates :button_url, url: true
   validates :image_credits_url, url: true
-  validates :position, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :position, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :image_position, presence: true
   validates :image, presence: true, content_type: /\Aimage\/.*\z/
 end

--- a/backend/app/models/homepage_section.rb
+++ b/backend/app/models/homepage_section.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: homepage_sections
+#
+#  id                :bigint           not null, primary key
+#  homepage_id       :bigint           not null
+#  button_url        :string
+#  image_position    :string
+#  image_credits_url :string
+#  background_color  :string
+#  position          :integer          default(1), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  subtitle          :string
+#  button_text       :string
+#  image_credits     :string
+#
+class HomepageSection < ApplicationRecord
+  belongs_to :homepage
+
+  has_one_attached :image, service: :local_public
+
+  enum :image_position, {left: "left", right: "right", cover: "cover"}, default: :left, _prefix: :image_position
+
+  translates :title, :subtitle, :button_text, :image_credits, touch: true, fallbacks_for_empty_translations: true
+  active_admin_translates :title, :subtitle, :button_text, :image_credits
+
+  translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+  translation_class.validates_presence_of :subtitle, if: -> { locale.to_s == I18n.default_locale.to_s }
+
+  validates :button_url, url: true
+  validates :image_credits_url, url: true
+  validates :position, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :image_position, presence: true
+  validates :image, presence: true, content_type: /\Aimage\/.*\z/
+end

--- a/backend/app/models/site_scope.rb
+++ b/backend/app/models/site_scope.rb
@@ -21,6 +21,7 @@
 #
 
 class SiteScope < ApplicationRecord
+  has_one :homepage, dependent: :destroy
   has_many :layer_groups
   has_many :site_pages
 

--- a/backend/app/serializers/homepage_journey_serializer.rb
+++ b/backend/app/serializers/homepage_journey_serializer.rb
@@ -1,0 +1,3 @@
+class HomepageJourneySerializer < ActiveModel::Serializer
+  attributes :title, :position
+end

--- a/backend/app/serializers/homepage_journey_serializer.rb
+++ b/backend/app/serializers/homepage_journey_serializer.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: homepage_journeys
+#
+#  id         :bigint           not null, primary key
+#  position   :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  title      :string
+#
 class HomepageJourneySerializer < ActiveModel::Serializer
   attributes :title, :position
 end

--- a/backend/app/serializers/homepage_section_serializer.rb
+++ b/backend/app/serializers/homepage_section_serializer.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: homepage_sections
+#
+#  id                :bigint           not null, primary key
+#  homepage_id       :bigint           not null
+#  button_url        :string
+#  image_position    :string
+#  image_credits_url :string
+#  background_color  :string
+#  position          :integer          default(1), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  subtitle          :string
+#  button_text       :string
+#  image_credits     :string
+#
 class HomepageSectionSerializer < ActiveModel::Serializer
   include BlobSerializer
 

--- a/backend/app/serializers/homepage_section_serializer.rb
+++ b/backend/app/serializers/homepage_section_serializer.rb
@@ -1,0 +1,10 @@
+class HomepageSectionSerializer < ActiveModel::Serializer
+  include BlobSerializer
+
+  attributes :title, :subtitle, :button_text, :button_url, :image_position, :image_credits, :image_credits_url,
+    :background_color, :position, :image
+
+  def image
+    image_links_for object.image
+  end
+end

--- a/backend/app/serializers/homepage_serializer.rb
+++ b/backend/app/serializers/homepage_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: homepages
+#
+#  id                  :bigint           not null, primary key
+#  homepage_journey_id :bigint
+#  site_scope_id       :bigint           not null
+#  credits_url         :string
+#  show_journeys       :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  title               :string
+#  subtitle            :string
+#  credits             :string
+#
 class HomepageSerializer < ActiveModel::Serializer
   include BlobSerializer
 

--- a/backend/app/serializers/homepage_serializer.rb
+++ b/backend/app/serializers/homepage_serializer.rb
@@ -1,0 +1,14 @@
+class HomepageSerializer < ActiveModel::Serializer
+  include BlobSerializer
+
+  cache key: "homepage_#{I18n.locale}"
+  attributes :title, :subtitle, :background_image, :credits, :credits_url
+  belongs_to :homepage_journey
+  has_many :homepage_sections do |serializer|
+    serializer.object.homepage_sections.order :position
+  end
+
+  def background_image
+    image_links_for object.background_image
+  end
+end

--- a/backend/app/views/admin/homepages/_form.html.slim
+++ b/backend/app/views/admin/homepages/_form.html.slim
@@ -1,0 +1,46 @@
+= semantic_form_for [:admin, resource], builder: ActiveAdmin::FormBuilder do |f|
+  = f.semantic_errors :homepage_sections, :base
+  = f.inputs "Translated fields" do
+    = f.translated_inputs switch_locale: false do |ff|
+      = ff.input :id, as: :hidden
+      = ff.input :locale, as: :hidden
+      = ff.input :title
+      = ff.input :subtitle
+      = ff.input :credits
+  = f.inputs "Common fields" do
+    = f.input :site_scope
+    = f.input :credits_url
+    == render "admin/shared/image_with_thumbnail", blob: :background_image, f: f, required: true
+
+  = f.inputs "Journeys" do
+    = f.input :show_journeys, required: false, input_html: {data: {if: "checked", action: "show", target: ".show-journeys-input"}}
+    = f.semantic_fields_for :homepage_journey, f.object.homepage_journey || f.object.build_homepage_journey do |ff|
+      = ff.input :position, wrapper_html: {class: "show-journeys-input"}
+      = ff.inputs "Translated fields", class: "inputs show-journeys-input" do
+        = ff.translated_inputs switch_locale: false do |fff|
+          = fff.input :id, as: :hidden
+          = fff.input :locale, as: :hidden
+          = fff.input :title
+
+  = f.inputs "Sections", class: "inputs has-many-collapsed" do
+    - f.has_many :homepage_sections, heading: false, sortable: :position, sortable_start: 1 do |ff|
+      = ff.semantic_errors
+      = ff.inputs (ff.object.new_record? ? "New Section" : ff.object.title.to_s), class: "inputs has-many-toggle-collapse" do
+        div class="has-many-section section-hidden"
+          = ff.inputs "Translated fields" do
+            - ff.translated_inputs switch_locale: false do |fff|
+              - fff.input :id, as: :hidden
+              - fff.input :locale, as: :hidden
+              - fff.input :title
+              - fff.input :subtitle
+              - fff.input :button_text
+              - fff.input :image_credits
+          = ff.inputs "Common fields" do
+            - ff.input :button_url
+            == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, required: true, inside_has_many_block: true
+            - ff.input :image_position, as: :select, collection: HomepageSection.image_positions.keys
+            - ff.input :image_credits_url
+            - ff.input :background_color
+          - unless ff.object.new_record?
+            - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")
+  = f.actions

--- a/backend/app/views/admin/shared/_image_with_thumbnail.html.slim
+++ b/backend/app/views/admin/shared/_image_with_thumbnail.html.slim
@@ -1,7 +1,9 @@
 - blob_object = f.object.public_send blob
 - inside_has_many_block = defined?(inside_has_many_block) ? inside_has_many_block : false
+- show_image = blob_object.present? && !blob_object.blob.new_record?
+- required = defined?(required) ? required && !show_image : false
 
-- if blob_object.present?
+- if show_image
   = link_to url_for(blob_object)
     = image_tag blob_object.variant(resize: "200x200"), class: "image-preview"
 - if inside_has_many_block

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get "/journeys", to: "journeys#index"
       get "/journeys/:id", to: "journeys#show"
       get "/menu-entries", to: "menu_entries#index"
+      get "/homepage", to: "homepages#show"
       resources :photos, only: :create
       resources :feedbacks, only: :create
     end

--- a/backend/db/migrate/20230405071245_create_homepage_journeys.rb
+++ b/backend/db/migrate/20230405071245_create_homepage_journeys.rb
@@ -1,0 +1,19 @@
+class CreateHomepageJourneys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :homepage_journeys do |t|
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        HomepageJourney.create_translation_table! title: :string
+      end
+
+      dir.down do
+        HomepageJourney.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230405071246_create_homepages.rb
+++ b/backend/db/migrate/20230405071246_create_homepages.rb
@@ -1,17 +1,17 @@
 class CreateHomepages < ActiveRecord::Migration[7.0]
   def change
     create_table :homepages do |t|
+      t.belongs_to :homepage_journey, foreign_key: {on_delete: :nullify}
+      t.belongs_to :site_scope, foreign_key: {on_delete: :cascade}, null: false, index: {unique: true}
       t.string :credits_url
-      t.integer :position, null: false, default: 1
       t.boolean :show_journeys, null: false, default: false
-      t.integer :journeys_position, null: false, default: 0
 
       t.timestamps
     end
 
     reversible do |dir|
       dir.up do
-        Homepage.create_translation_table! title: :string, subtitle: :string, credits: :string, journeys_title: :string
+        Homepage.create_translation_table! title: :string, subtitle: :string, credits: :string
       end
 
       dir.down do

--- a/backend/db/migrate/20230405071246_create_homepages.rb
+++ b/backend/db/migrate/20230405071246_create_homepages.rb
@@ -1,0 +1,22 @@
+class CreateHomepages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :homepages do |t|
+      t.string :credits_url
+      t.integer :position, null: false, default: 1
+      t.boolean :show_journeys, null: false, default: false
+      t.integer :journeys_position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        Homepage.create_translation_table! title: :string, subtitle: :string, credits: :string, journeys_title: :string
+      end
+
+      dir.down do
+        Homepage.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230405074139_create_homepage_sections.rb
+++ b/backend/db/migrate/20230405074139_create_homepage_sections.rb
@@ -1,0 +1,24 @@
+class CreateHomepageSections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :homepage_sections do |t|
+      t.belongs_to :homepage, null: false, foreign_key: {on_delete: :cascade}
+      t.string :button_url
+      t.string :image_position
+      t.string :image_credits_url
+      t.string :background_color
+      t.integer :position, null: false, default: 1
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        HomepageSection.create_translation_table! title: :string, subtitle: :string, button_text: :string, image_credits: :string
+      end
+
+      dir.down do
+        HomepageSection.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_05_071246) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,6 +138,31 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_071246) do
     t.string "language", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "homepage_section_translations", force: :cascade do |t|
+    t.bigint "homepage_section_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "subtitle"
+    t.string "button_text"
+    t.string "image_credits"
+    t.index ["homepage_section_id"], name: "index_homepage_section_translations_on_homepage_section_id"
+    t.index ["locale"], name: "index_homepage_section_translations_on_locale"
+  end
+
+  create_table "homepage_sections", force: :cascade do |t|
+    t.bigint "homepage_id", null: false
+    t.string "button_url"
+    t.string "image_position"
+    t.string "image_credits_url"
+    t.string "background_color"
+    t.integer "position", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["homepage_id"], name: "index_homepage_sections_on_homepage_id"
   end
 
   create_table "homepage_translations", force: :cascade do |t|
@@ -503,6 +528,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_071246) do
   add_foreign_key "agrupations", "layers"
   add_foreign_key "feedback_fields", "feedback_fields", column: "parent_id", on_delete: :cascade
   add_foreign_key "feedback_fields", "feedbacks", on_delete: :cascade
+  add_foreign_key "homepage_sections", "homepages", on_delete: :cascade
   add_foreign_key "identities", "users"
   add_foreign_key "indicators", "categories"
   add_foreign_key "journey_steps", "journeys", on_delete: :cascade

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_30_113540) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_05_071246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,6 +136,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_30_113540) do
 
   create_table "feedbacks", force: :cascade do |t|
     t.string "language", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "homepage_translations", force: :cascade do |t|
+    t.bigint "homepage_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "subtitle"
+    t.string "credits"
+    t.string "journeys_title"
+    t.index ["homepage_id"], name: "index_homepage_translations_on_homepage_id"
+    t.index ["locale"], name: "index_homepage_translations_on_locale"
+  end
+
+  create_table "homepages", force: :cascade do |t|
+    t.string "credits_url"
+    t.integer "position", default: 1, null: false
+    t.boolean "show_journeys", default: false, null: false
+    t.integer "journeys_position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -140,6 +140,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "homepage_journey_translations", force: :cascade do |t|
+    t.bigint "homepage_journey_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.index ["homepage_journey_id"], name: "index_homepage_journey_translations_on_homepage_journey_id"
+    t.index ["locale"], name: "index_homepage_journey_translations_on_locale"
+  end
+
+  create_table "homepage_journeys", force: :cascade do |t|
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "homepage_section_translations", force: :cascade do |t|
     t.bigint "homepage_section_id", null: false
     t.string "locale", null: false
@@ -173,18 +189,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
     t.string "title"
     t.string "subtitle"
     t.string "credits"
-    t.string "journeys_title"
     t.index ["homepage_id"], name: "index_homepage_translations_on_homepage_id"
     t.index ["locale"], name: "index_homepage_translations_on_locale"
   end
 
   create_table "homepages", force: :cascade do |t|
+    t.bigint "homepage_journey_id"
+    t.bigint "site_scope_id", null: false
     t.string "credits_url"
-    t.integer "position", default: 1, null: false
     t.boolean "show_journeys", default: false, null: false
-    t.integer "journeys_position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["homepage_journey_id"], name: "index_homepages_on_homepage_journey_id"
+    t.index ["site_scope_id"], name: "index_homepages_on_site_scope_id", unique: true
   end
 
   create_table "identities", force: :cascade do |t|
@@ -529,6 +546,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
   add_foreign_key "feedback_fields", "feedback_fields", column: "parent_id", on_delete: :cascade
   add_foreign_key "feedback_fields", "feedbacks", on_delete: :cascade
   add_foreign_key "homepage_sections", "homepages", on_delete: :cascade
+  add_foreign_key "homepages", "homepage_journeys", on_delete: :nullify
+  add_foreign_key "homepages", "site_scopes", on_delete: :cascade
   add_foreign_key "identities", "users"
   add_foreign_key "indicators", "categories"
   add_foreign_key "journey_steps", "journeys", on_delete: :cascade

--- a/backend/spec/factories/homepage_journeys.rb
+++ b/backend/spec/factories/homepage_journeys.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: homepage_journeys
+#
+#  id         :bigint           not null, primary key
+#  position   :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  title      :string
+#
+FactoryBot.define do
+  factory :homepage_journey do
+    sequence(:title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+  end
+end

--- a/backend/spec/factories/homepage_sections.rb
+++ b/backend/spec/factories/homepage_sections.rb
@@ -39,6 +39,14 @@ FactoryBot.define do
     sequence(:image_position) do |n|
       HomepageSection.image_positions.keys.sample random: Random.new(n)
     end
+    sequence(:image_credits) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:image_credits_url) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
     sequence(:background_color) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Color.hex_color

--- a/backend/spec/factories/homepage_sections.rb
+++ b/backend/spec/factories/homepage_sections.rb
@@ -1,21 +1,24 @@
 # == Schema Information
 #
-# Table name: homepages
+# Table name: homepage_sections
 #
 #  id                :bigint           not null, primary key
-#  credits_url       :string
+#  homepage_id       :bigint           not null
+#  button_url        :string
+#  image_position    :string
+#  image_credits_url :string
+#  background_color  :string
 #  position          :integer          default(1), not null
-#  show_journeys     :boolean          default(FALSE), not null
-#  journeys_position :integer          default(0), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  title             :string
 #  subtitle          :string
-#  credits           :string
-#  journeys_title    :string
+#  button_text       :string
+#  image_credits     :string
 #
 FactoryBot.define do
-  factory :homepage do
+  factory :homepage_section do
+    homepage
     sequence(:title) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Lorem.sentence
@@ -24,22 +27,21 @@ FactoryBot.define do
       Faker::Config.random = Random.new(n)
       Faker::Lorem.sentence
     end
-    sequence(:credits) do |n|
+    sequence(:button_text) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Lorem.sentence
     end
-    sequence(:credits_url) do |n|
+    sequence(:button_url) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Internet.url
     end
-    background_image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
-    sequence(:show_journeys) do |n|
-      Faker::Config.random = Random.new(n)
-      Faker::Boolean.boolean
+    image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    sequence(:image_position) do |n|
+      HomepageSection.image_positions.keys.sample random: Random.new(n)
     end
-    sequence(:journeys_title) do |n|
+    sequence(:background_color) do |n|
       Faker::Config.random = Random.new(n)
-      Faker::Lorem.sentence
+      Faker::Color.hex_color
     end
   end
 end

--- a/backend/spec/factories/homepages.rb
+++ b/backend/spec/factories/homepages.rb
@@ -2,20 +2,21 @@
 #
 # Table name: homepages
 #
-#  id                :bigint           not null, primary key
-#  credits_url       :string
-#  position          :integer          default(1), not null
-#  show_journeys     :boolean          default(FALSE), not null
-#  journeys_position :integer          default(0), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  title             :string
-#  subtitle          :string
-#  credits           :string
-#  journeys_title    :string
+#  id                  :bigint           not null, primary key
+#  homepage_journey_id :bigint
+#  site_scope_id       :bigint           not null
+#  credits_url         :string
+#  show_journeys       :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  title               :string
+#  subtitle            :string
+#  credits             :string
 #
 FactoryBot.define do
   factory :homepage do
+    site_scope
+    homepage_journey
     sequence(:title) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Lorem.sentence
@@ -36,10 +37,6 @@ FactoryBot.define do
     sequence(:show_journeys) do |n|
       Faker::Config.random = Random.new(n)
       Faker::Boolean.boolean
-    end
-    sequence(:journeys_title) do |n|
-      Faker::Config.random = Random.new(n)
-      Faker::Lorem.sentence
     end
   end
 end

--- a/backend/spec/factories/homepages.rb
+++ b/backend/spec/factories/homepages.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :homepage do
+    sequence(:title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:subtitle) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:credits) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:credits_url) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+    background_image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    sequence(:show_journeys) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Boolean.boolean
+    end
+    sequence(:journeys_title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+  end
+end

--- a/backend/spec/fixtures/snapshots/api/v1/get_homepage.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get_homepage.json
@@ -1,0 +1,63 @@
+{
+  "data": {
+    "id": "40",
+    "type": "homepages",
+    "attributes": {
+      "title": "Enim repellat pariatur est.",
+      "subtitle": "Enim repellat pariatur est.",
+      "background_image": {
+        "small": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--169133b0d3552ad330a879aa981533fd2469ee73/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg",
+        "medium": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--169133b0d3552ad330a879aa981533fd2469ee73/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg",
+        "original": "http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--169133b0d3552ad330a879aa981533fd2469ee73/picture.jpg"
+      },
+      "credits": "Enim repellat pariatur est.",
+      "credits_url": "http://kutch-spencer.com/moises"
+    },
+    "relationships": {
+      "homepage_journey": {
+        "data": {
+          "id": "41",
+          "type": "homepage_journeys"
+        }
+      },
+      "homepage_sections": {
+        "data": [
+          {
+            "id": "21",
+            "type": "homepage_sections"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "41",
+      "type": "homepage_journeys",
+      "attributes": {
+        "title": "Enim repellat pariatur est.",
+        "position": 0
+      }
+    },
+    {
+      "id": "21",
+      "type": "homepage_sections",
+      "attributes": {
+        "title": "Enim repellat pariatur est.",
+        "subtitle": "Enim repellat pariatur est.",
+        "button_text": "Enim repellat pariatur est.",
+        "button_url": "http://kutch-spencer.com/moises",
+        "image_position": "right",
+        "image_credits": "Enim repellat pariatur est.",
+        "image_credits_url": "http://kutch-spencer.com/moises",
+        "background_color": "#ffdbdb",
+        "position": 1,
+        "image": {
+          "small": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcG9CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--bb672838677b93d45f79bc63362a06aac8f44ac1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg",
+          "medium": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcG9CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--bb672838677b93d45f79bc63362a06aac8f44ac1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg",
+          "original": "http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcG9CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--bb672838677b93d45f79bc63362a06aac8f44ac1/picture.jpg"
+        }
+      }
+    }
+  ]
+}

--- a/backend/spec/models/homepage_journey_spec.rb
+++ b/backend/spec/models/homepage_journey_spec.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: homepage_journeys
+#
+#  id         :bigint           not null, primary key
+#  position   :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  title      :string
+#
+require "rails_helper"
+
+RSpec.describe HomepageJourney, type: :model do
+  subject { build(:homepage_journey) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+end

--- a/backend/spec/models/homepage_section_spec.rb
+++ b/backend/spec/models/homepage_section_spec.rb
@@ -1,0 +1,72 @@
+# == Schema Information
+#
+# Table name: homepage_sections
+#
+#  id                :bigint           not null, primary key
+#  homepage_id       :bigint           not null
+#  button_url        :string
+#  image_position    :string
+#  image_credits_url :string
+#  background_color  :string
+#  position          :integer          default(1), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  subtitle          :string
+#  button_text       :string
+#  image_credits     :string
+#
+require 'rails_helper'
+
+RSpec.describe HomepageSection, type: :model do
+  subject { build(:homepage_section) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid when button_url is not url" do
+    subject.button_url = "WRONG_URL"
+    expect(subject).to have(1).errors_on(:button_url)
+  end
+
+  it "should not be valid when image_credits_url is not url" do
+    subject.image_credits_url = "WRONG_URL"
+    expect(subject).to have(1).errors_on(:image_credits_url)
+  end
+
+  it "should not be valid without image" do
+    subject.image = nil
+    expect(subject).to have(1).errors_on(:image)
+  end
+
+  it "should not be valid without image_position" do
+    subject.image_position = nil
+    expect(subject).to have(1).errors_on(:image_position)
+  end
+
+  it "should not be valid when image is not image" do
+    subject.image.attach fixture_file_upload("document.pdf")
+    expect(subject).to have(1).errors_on(:image)
+  end
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+
+  it "should not be valid without subtitle" do
+    subject.subtitle = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.subtitle"]).to include("can't be blank")
+  end
+end

--- a/backend/spec/models/homepage_section_spec.rb
+++ b/backend/spec/models/homepage_section_spec.rb
@@ -16,7 +16,7 @@
 #  button_text       :string
 #  image_credits     :string
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HomepageSection, type: :model do
   subject { build(:homepage_section) }

--- a/backend/spec/models/homepage_spec.rb
+++ b/backend/spec/models/homepage_spec.rb
@@ -2,19 +2,18 @@
 #
 # Table name: homepages
 #
-#  id                :bigint           not null, primary key
-#  credits_url       :string
-#  position          :integer          default(1), not null
-#  show_journeys     :boolean          default(FALSE), not null
-#  journeys_position :integer          default(0), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  title             :string
-#  subtitle          :string
-#  credits           :string
-#  journeys_title    :string
+#  id                  :bigint           not null, primary key
+#  homepage_journey_id :bigint
+#  site_scope_id       :bigint           not null
+#  credits_url         :string
+#  show_journeys       :boolean          default(FALSE), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  title               :string
+#  subtitle            :string
+#  credits             :string
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Homepage, type: :model do
   subject { build(:homepage) }
@@ -36,16 +35,6 @@ RSpec.describe Homepage, type: :model do
     expect(subject).to have(1).errors_on(:background_image)
   end
 
-  it "should not be valid without position" do
-    subject.position = nil
-    expect(subject).to have(2).errors_on(:position)
-  end
-
-  it "should not be valid when position is negative" do
-    subject.position = -1
-    expect(subject).to have(1).errors_on(:position)
-  end
-
   it "should not be valid without title" do
     subject.title = nil
     expect(subject.save).to be_falsey
@@ -58,23 +47,17 @@ RSpec.describe Homepage, type: :model do
     expect(subject.errors["translations.subtitle"]).to include("can't be blank")
   end
 
+  it "should not be valid when multiple homepages uses same site scope" do
+    subject.save!
+    expect(build(:homepage, site_scope: subject.site_scope)).to have(1).errors_on(:site_scope_id)
+  end
+
   context "when show_journeys is true" do
-    before { subject.show_journeys = true }
+    subject { build(:homepage, show_journeys: true) }
 
-    it "should not be valid without journeys_title" do
-      subject.journeys_title = nil
-      expect(subject.save).to be_falsey
-      expect(subject.errors["translations.journeys_title"]).to include("can't be blank")
-    end
-
-    it "should not be valid without journeys_position" do
-      subject.journeys_position = nil
-      expect(subject).to have(2).errors_on(:journeys_position)
-    end
-
-    it "should not be valid when journeys_position is negative" do
-      subject.journeys_position = -1
-      expect(subject).to have(1).errors_on(:journeys_position)
+    it "should not be valid without homepage_journey" do
+      subject.homepage_journey = nil
+      expect(subject).to have(1).errors_on(:homepage_journey)
     end
   end
 end

--- a/backend/spec/models/homepage_spec.rb
+++ b/backend/spec/models/homepage_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: homepages
+#
+#  id                :bigint           not null, primary key
+#  credits_url       :string
+#  position          :integer          default(1), not null
+#  show_journeys     :boolean          default(FALSE), not null
+#  journeys_position :integer          default(0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  subtitle          :string
+#  credits           :string
+#  journeys_title    :string
+#
 require 'rails_helper'
 
 RSpec.describe Homepage, type: :model do

--- a/backend/spec/models/homepage_spec.rb
+++ b/backend/spec/models/homepage_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Homepage, type: :model do
+  subject { build(:homepage) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid when credits_url is not url" do
+    subject.credits_url = "WRONG_URL"
+    expect(subject).to have(1).errors_on(:credits_url)
+  end
+
+  it "should not be valid without background_image" do
+    subject.background_image = nil
+    expect(subject).to have(1).errors_on(:background_image)
+  end
+
+  it "should not be valid when background_image is not image" do
+    subject.background_image.attach fixture_file_upload("document.pdf")
+    expect(subject).to have(1).errors_on(:background_image)
+  end
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+
+  it "should not be valid without subtitle" do
+    subject.subtitle = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.subtitle"]).to include("can't be blank")
+  end
+
+  context "when show_journeys is true" do
+    before { subject.show_journeys = true }
+
+    it "should not be valid without journeys_title" do
+      subject.journeys_title = nil
+      expect(subject.save).to be_falsey
+      expect(subject.errors["translations.journeys_title"]).to include("can't be blank")
+    end
+
+    it "should not be valid without journeys_position" do
+      subject.journeys_position = nil
+      expect(subject).to have(2).errors_on(:journeys_position)
+    end
+
+    it "should not be valid when journeys_position is negative" do
+      subject.journeys_position = -1
+      expect(subject).to have(1).errors_on(:journeys_position)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/homepages_spec.rb
+++ b/backend/spec/requests/api/v1/homepages_spec.rb
@@ -1,0 +1,32 @@
+require "swagger_helper"
+
+RSpec.describe "API V1 Homepages", type: :request do
+  path "/api/homepage" do
+    get "Get homepage for appropriate site scope" do
+      tags "Homepage"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :site_scope, in: :query, type: :string, description: "Site scope subdomain. Fallbacks to default site scope.", required: false
+      parameter name: :locale, in: :query, type: :string, description: "Used language. Default: en", required: false
+
+      let!(:homepage_journey) { create :homepage_journey }
+      let!(:homepage) { create :homepage, show_journeys: true, homepage_journey: homepage_journey }
+      let!(:homepage_section) { create :homepage_section, homepage: homepage }
+      let(:site_scope) { homepage.site_scope.subdomain }
+
+      response "200", :success do
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/get_homepage")
+        end
+      end
+
+      response "404", "Site scope does not have homepage", generate_swagger_example: true do
+        let(:site_scope) { create(:site_scope).subdomain }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/systems/admin/homepages_spec.rb
+++ b/backend/spec/systems/admin/homepages_spec.rb
@@ -1,0 +1,190 @@
+require "system_helper"
+
+RSpec.describe "Admin: Homepages", type: :system do
+  let(:admin_user) { create :admin_user }
+
+  before { login_as admin_user }
+
+  describe "#index" do
+    let!(:homepages) { create_list :homepage, 3 }
+
+    before { visit admin_homepages_path }
+
+    it "shows homepages" do
+      Homepage.all.each do |homepage|
+        expect(page).to have_text(homepage.id)
+        expect(page).to have_text(homepage.title)
+        expect(page).to have_text(homepage.subtitle)
+        expect(page).to have_text(homepage.site_scope.name)
+      end
+    end
+  end
+
+  describe "#show" do
+    let!(:homepage_journey) { create :homepage_journey }
+    let!(:homepage) { create :homepage, show_journeys: true, homepage_journey: homepage_journey }
+    let!(:homepage_section) { create :homepage_section, homepage: homepage }
+
+    before do
+      visit admin_homepages_path
+      find("a[href='/admin/homepages/#{homepage.id}']", text: "View").click
+    end
+
+    it "shows homepage detail" do
+      expect(page).to have_text(homepage.id)
+      expect(page).to have_text(homepage.title)
+      expect(page).to have_text(homepage.subtitle)
+      expect(page).to have_text(homepage.site_scope.name)
+      expect(page).to have_text(homepage.credits)
+      expect(page).to have_text(homepage.credits_url)
+    end
+
+    it "shows journey information" do
+      expect(page).to have_text(homepage_journey.id)
+      expect(page).to have_text(homepage_journey.title)
+    end
+
+    it "shows homepage section information" do
+      expect(page).to have_text(homepage_section.id)
+      expect(page).to have_text(homepage_section.title)
+      expect(page).to have_text(homepage_section.subtitle)
+      expect(page).to have_text(homepage_section.button_text)
+      expect(page).to have_text(homepage_section.button_url)
+      expect(page).to have_text(homepage_section.image_credits)
+      expect(page).to have_text(homepage_section.image_credits_url)
+    end
+  end
+
+  describe "#create" do
+    let!(:site_scope) { create :site_scope }
+    let(:new_homepage) { Homepage.last }
+
+    before do
+      visit admin_homepages_path
+      click_on "New Homepage"
+    end
+
+    it "allows to create new homepage" do
+      # base homepage
+      fill_in "homepage[translations_attributes][0][title]", with: "New title"
+      fill_in "homepage[translations_attributes][0][subtitle]", with: "New subtitle"
+      fill_in "homepage[translations_attributes][0][credits]", with: "New credits"
+      select site_scope.name, from: "homepage[site_scope_id]"
+      fill_in "homepage[credits_url]", with: "https://credits-url.com"
+      attach_file "homepage[background_image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      # journeys
+      check "homepage[show_journeys]"
+      fill_in "homepage[homepage_journey_attributes][position]", with: "0"
+      fill_in "homepage[homepage_journey_attributes][translations_attributes][0][title]", with: "New journey title"
+      # homepage sections
+      click_on "Add New Homepage section"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][title]", with: "New section title"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][subtitle]", with: "New section subtitle"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][button_text]", with: "New section button text"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][image_credits]", with: "New section image credits"
+      fill_in "homepage[homepage_sections_attributes][0][button_url]", with: "https://button-url.com"
+      attach_file "homepage[homepage_sections_attributes][0][image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      select "cover", from: "homepage[homepage_sections_attributes][0][image_position]"
+      fill_in "homepage[homepage_sections_attributes][0][image_credits_url]", with: "https://image-credits-url.com"
+
+      click_on "Create Homepage"
+
+      expect(page).to have_current_path(admin_homepage_path(new_homepage))
+      expect(page).to have_text("Homepage was successfully created.")
+      expect(page).to have_text("New title")
+      expect(page).to have_text("New subtitle")
+      expect(page).to have_text("New credits")
+      expect(page).to have_text(site_scope.name)
+      expect(page).to have_text("https://credits-url.com")
+      expect(page).to have_text("New journey title")
+      expect(page).to have_text("New section title")
+      expect(page).to have_text("New section subtitle")
+      expect(page).to have_text("New section button text")
+      expect(page).to have_text("New section image credits")
+      expect(page).to have_text("https://button-url.com")
+      expect(page).to have_text("cover")
+      expect(page).to have_text("https://image-credits-url.com")
+    end
+
+    it "shows error when validation fails" do
+      fill_in "homepage[translations_attributes][0][title]", with: ""
+
+      click_on "Create Homepage"
+
+      expect(page).to have_current_path(admin_homepages_path)
+      expect(page).to have_text("can't be blank")
+    end
+  end
+
+  describe "#update" do
+    let!(:site_scope) { create :site_scope }
+    let!(:homepage_journey) { create :homepage_journey }
+    let!(:homepage) { create :homepage, show_journeys: true, homepage_journey: homepage_journey }
+    let!(:homepage_section) { create :homepage_section, homepage: homepage }
+
+    before do
+      visit admin_homepages_path
+      find("a[href='/admin/homepages/#{homepage.id}/edit']").click
+    end
+
+    it "allows to update existing homepage" do
+      # base homepage
+      fill_in "homepage[translations_attributes][0][title]", with: "Updated title"
+      fill_in "homepage[translations_attributes][0][subtitle]", with: "Updated subtitle"
+      fill_in "homepage[translations_attributes][0][credits]", with: "Updated credits"
+      select site_scope.name, from: "homepage[site_scope_id]"
+      fill_in "homepage[credits_url]", with: "https://credits-url.com"
+      attach_file "homepage[background_image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      # journeys
+      check "homepage[show_journeys]"
+      fill_in "homepage[homepage_journey_attributes][position]", with: "0"
+      fill_in "homepage[homepage_journey_attributes][translations_attributes][0][title]", with: "Updated journey title"
+      # homepage sections
+      all("fieldset.has-many-toggle-collapse").last.click
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][title]", with: "Updated section title"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][subtitle]", with: "Updated section subtitle"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][button_text]", with: "Updated section button text"
+      fill_in "homepage[homepage_sections_attributes][0][translations_attributes][0][image_credits]", with: "Updated section image credits"
+      fill_in "homepage[homepage_sections_attributes][0][button_url]", with: "https://button-url.com"
+      attach_file "homepage[homepage_sections_attributes][0][image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      select "cover", from: "homepage[homepage_sections_attributes][0][image_position]"
+      fill_in "homepage[homepage_sections_attributes][0][image_credits_url]", with: "https://image-credits-url.com"
+
+      click_on "Update Homepage"
+
+      expect(page).to have_current_path(admin_homepage_path(homepage))
+      expect(page).to have_text("Homepage was successfully updated.")
+      expect(page).to have_text("Updated title")
+      expect(page).to have_text("Updated subtitle")
+      expect(page).to have_text("Updated credits")
+      expect(page).to have_text(site_scope.name)
+      expect(page).to have_text("https://credits-url.com")
+      expect(page).to have_text("Updated journey title")
+      expect(page).to have_text("Updated section title")
+      expect(page).to have_text("Updated section subtitle")
+      expect(page).to have_text("Updated section button text")
+      expect(page).to have_text("Updated section image credits")
+      expect(page).to have_text("https://button-url.com")
+      expect(page).to have_text("cover")
+      expect(page).to have_text("https://image-credits-url.com")
+    end
+  end
+
+  describe "#delete" do
+    let!(:homepage) { create :homepage, title: "Custom title" }
+
+    before do
+      visit admin_homepages_path
+    end
+
+    it "deletes existing homepage" do
+      expect(page).to have_text(homepage.title)
+
+      accept_confirm do
+        find("a[data-method='delete'][href='/admin/homepages/#{homepage.id}']").click
+      end
+
+      expect(page).not_to have_text(homepage.title)
+    end
+  end
+end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -47,7 +47,7 @@ paths:
                   data_units: molestiae
                   processing: molestiae
                   description: Et quaerat omnis veniam.
-                  id: 9
+                  id: 73
                   layer_group_id:
                   slug: Layer-3
                   layer_type:
@@ -60,8 +60,8 @@ paths:
                   interactivity:
                   opacity: 25.0
                   query: Et quaerat omnis veniam.
-                  created_at: '2023-04-03T08:35:05.410+02:00'
-                  updated_at: '2023-04-03T08:35:05.410+02:00'
+                  created_at: '2023-04-05T16:04:18.154+02:00'
+                  updated_at: '2023-04-05T16:04:18.156+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -91,7 +91,7 @@ paths:
                   data_units: cum
                   processing: cum
                   description: Placeat commodi libero et.
-                  id: 8
+                  id: 72
                   layer_group_id:
                   slug: Layer-2
                   layer_type:
@@ -104,8 +104,8 @@ paths:
                   interactivity:
                   opacity: 41.0
                   query: Placeat commodi libero et.
-                  created_at: '2023-04-03T08:35:05.407+02:00'
-                  updated_at: '2023-04-03T08:35:05.407+02:00'
+                  created_at: '2023-04-05T16:04:18.151+02:00'
+                  updated_at: '2023-04-05T16:04:18.153+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -135,7 +135,7 @@ paths:
                   data_units: voluptatem
                   processing: voluptatem
                   description: Enim repellat pariatur est.
-                  id: 7
+                  id: 71
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -148,8 +148,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-03T08:35:05.404+02:00'
-                  updated_at: '2023-04-03T08:35:05.404+02:00'
+                  created_at: '2023-04-05T16:04:18.147+02:00'
+                  updated_at: '2023-04-05T16:04:18.149+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -208,7 +208,7 @@ paths:
                   data_units:
                   processing:
                   description:
-                  id: 11
+                  id: 75
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -221,8 +221,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-03T08:35:05.440+02:00'
-                  updated_at: '2023-04-03T08:35:05.440+02:00'
+                  created_at: '2023-04-05T16:04:18.181+02:00'
+                  updated_at: '2023-04-05T16:04:18.183+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -292,7 +292,7 @@ paths:
                   data_units: voluptatem
                   processing: voluptatem
                   description: Enim repellat pariatur est.
-                  id: 18
+                  id: 82
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -305,8 +305,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-03T08:35:05.496+02:00'
-                  updated_at: '2023-04-03T08:35:05.496+02:00'
+                  created_at: '2023-04-05T16:04:18.241+02:00'
+                  updated_at: '2023-04-05T16:04:18.243+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -372,7 +372,7 @@ paths:
                   data_units:
                   processing:
                   description:
-                  id: 22
+                  id: 86
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -385,8 +385,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-03T08:35:05.566+02:00'
-                  updated_at: '2023-04-03T08:35:05.566+02:00'
+                  created_at: '2023-04-05T16:04:18.291+02:00'
+                  updated_at: '2023-04-05T16:04:18.298+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -450,7 +450,7 @@ paths:
                 - name: AAA
                   linkback_text: Enim repellat pariatur. Earum modi eos. Libero tempora
                     exercitationem.
-                  id: 5
+                  id: 107
                   color: "#ffdbdb"
                   subdomain: voluptatem
                   has_analysis: true
@@ -467,7 +467,7 @@ paths:
                 - name: BBB
                   linkback_text: Placeat commodi libero. Quo recusandae repellat.
                     Sunt commodi tempore.
-                  id: 6
+                  id: 108
                   color: "#eaf1ea"
                   subdomain: cum
                   has_analysis: true
@@ -493,7 +493,7 @@ paths:
           content:
             application/json:
               example:
-                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2ODA1OTAxMDV9.F-3A3Fv23_NyO2q6Wy9uocoCGHPtqVpbyqzOzCN33YA
+                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyNSwiZXhwIjoxNjgwNzg5ODU4fQ.Y74Ut2kqje96DmevsNFN61EhoCuZLTzLX2Jkqm2ddZc
         '401':
           description: Unauthorized
           content:
@@ -533,7 +533,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '4'
+                - id: '31'
                   type: categories
                   attributes:
                     name: voluptatem
@@ -543,7 +543,7 @@ paths:
                   relationships:
                     indicators:
                       data: []
-                - id: '5'
+                - id: '32'
                   type: categories
                   attributes:
                     name: cum
@@ -553,7 +553,7 @@ paths:
                   relationships:
                     indicators:
                       data: []
-                - id: '6'
+                - id: '33'
                   type: categories
                   attributes:
                     name: molestiae
@@ -578,31 +578,31 @@ paths:
             application/json:
               example:
                 data:
-                  id: '2'
+                  id: '16'
                   type: feedbacks
                   attributes:
                     language: en
-                    created_at: '2023-04-03T08:35:05.982+02:00'
-                    updated_at: '2023-04-03T08:35:05.982+02:00'
+                    created_at: '2023-04-05T16:04:18.597+02:00'
+                    updated_at: '2023-04-05T16:04:18.597+02:00'
                   relationships:
                     feedback_fields:
                       data:
-                      - id: '8'
+                      - id: '36'
                         type: feedback_fields
-                      - id: '9'
+                      - id: '37'
                         type: feedback_fields
-                      - id: '10'
+                      - id: '38'
                         type: feedback_fields
-                      - id: '11'
+                      - id: '39'
                         type: feedback_fields
-                      - id: '12'
+                      - id: '40'
                         type: feedback_fields
-                      - id: '13'
+                      - id: '41'
                         type: feedback_fields
-                      - id: '14'
+                      - id: '42'
                         type: feedback_fields
                 included:
-                - id: '8'
+                - id: '36'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -610,18 +610,18 @@ paths:
                     answer:
                       slug: red
                       value: Red
-                    created_at: '2023-04-03T08:35:05.983+02:00'
-                    updated_at: '2023-04-03T08:35:05.983+02:00'
+                    created_at: '2023-04-05T16:04:18.598+02:00'
+                    updated_at: '2023-04-05T16:04:18.598+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '9'
+                - id: '37'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: multiple_choice
@@ -633,18 +633,18 @@ paths:
                       value:
                       - Green
                       - Yellow
-                    created_at: '2023-04-03T08:35:05.984+02:00'
-                    updated_at: '2023-04-03T08:35:05.984+02:00'
+                    created_at: '2023-04-05T16:04:18.599+02:00'
+                    updated_at: '2023-04-05T16:04:18.599+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '10'
+                - id: '38'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: boolean_choice
@@ -652,18 +652,18 @@ paths:
                     answer:
                       slug: 'true'
                       value: true
-                    created_at: '2023-04-03T08:35:05.985+02:00'
-                    updated_at: '2023-04-03T08:35:05.985+02:00'
+                    created_at: '2023-04-05T16:04:18.600+02:00'
+                    updated_at: '2023-04-05T16:04:18.600+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '11'
+                - id: '39'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: free_answer
@@ -671,39 +671,39 @@ paths:
                     answer:
                       slug: i-don-t-know
                       value: I don't know
-                    created_at: '2023-04-03T08:35:05.986+02:00'
-                    updated_at: '2023-04-03T08:35:05.986+02:00'
+                    created_at: '2023-04-05T16:04:18.601+02:00'
+                    updated_at: '2023-04-05T16:04:18.601+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '12'
+                - id: '40'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: rating
                     question: Color preferences
                     answer:
-                    created_at: '2023-04-03T08:35:05.987+02:00'
-                    updated_at: '2023-04-03T08:35:05.987+02:00'
+                    created_at: '2023-04-05T16:04:18.602+02:00'
+                    updated_at: '2023-04-05T16:04:18.602+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data:
-                      - id: '13'
+                      - id: '41'
                         type: feedback_fields
-                      - id: '14'
+                      - id: '42'
                         type: feedback_fields
-                - id: '13'
+                - id: '41'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -711,20 +711,20 @@ paths:
                     answer:
                       slug: '3'
                       value: 3
-                    created_at: '2023-04-03T08:35:05.988+02:00'
-                    updated_at: '2023-04-03T08:35:05.988+02:00'
+                    created_at: '2023-04-05T16:04:18.603+02:00'
+                    updated_at: '2023-04-05T16:04:18.603+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
-                        id: '12'
+                        id: '40'
                         type: feedback_fields
                     children:
                       data: []
-                - id: '14'
+                - id: '42'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -732,16 +732,16 @@ paths:
                     answer:
                       slug: '5'
                       value: 5
-                    created_at: '2023-04-03T08:35:05.989+02:00'
-                    updated_at: '2023-04-03T08:35:05.989+02:00'
+                    created_at: '2023-04-05T16:04:18.604+02:00'
+                    updated_at: '2023-04-05T16:04:18.604+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '2'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
-                        id: '12'
+                        id: '40'
                         type: feedback_fields
                     children:
                       data: []
@@ -798,6 +798,81 @@ paths:
                   - language
               required:
               - feedback
+  "/api/homepage":
+    get:
+      summary: Get homepage for appropriate site scope
+      tags:
+      - Homepage
+      parameters:
+      - name: site_scope
+        in: query
+        description: Site scope subdomain. Fallbacks to default site scope.
+        required: false
+        schema:
+          type: string
+      - name: locale
+        in: query
+        description: 'Used language. Default: en'
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                  id: '52'
+                  type: homepages
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    subtitle: Enim repellat pariatur est.
+                    background_image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBckVCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2416f72e23f2fbf3a4c0ff9908ec8b6ae81e9cd6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBckVCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2416f72e23f2fbf3a4c0ff9908ec8b6ae81e9cd6/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBckVCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2416f72e23f2fbf3a4c0ff9908ec8b6ae81e9cd6/picture.jpg
+                    credits: Enim repellat pariatur est.
+                    credits_url: http://kutch-spencer.com/moises
+                  relationships:
+                    homepage_journey:
+                      data:
+                        id: '53'
+                        type: homepage_journeys
+                    homepage_sections:
+                      data:
+                      - id: '33'
+                        type: homepage_sections
+                included:
+                - id: '53'
+                  type: homepage_journeys
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    position: 0
+                - id: '33'
+                  type: homepage_sections
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    subtitle: Enim repellat pariatur est.
+                    button_text: Enim repellat pariatur est.
+                    button_url: http://kutch-spencer.com/moises
+                    image_position: right
+                    image_credits: Enim repellat pariatur est.
+                    image_credits_url: http://kutch-spencer.com/moises
+                    background_color: "#ffdbdb"
+                    position: 1
+                    image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcklCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c10bc8635c823d8d850b51e47d2366e6de30ae7e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcklCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c10bc8635c823d8d850b51e47d2366e6de30ae7e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcklCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c10bc8635c823d8d850b51e47d2366e6de30ae7e/picture.jpg
+        '404':
+          description: Site scope does not have homepage
+          content:
+            application/json:
+              example:
+                errors:
+                - status: '404'
+                  title: Record not found
   "/api/indicators":
     get:
       summary: Get list of indicators
@@ -817,7 +892,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '4'
+                - id: '17'
                   type: indicators
                   attributes:
                     name: voluptatem
@@ -831,9 +906,9 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '10'
+                        id: '37'
                         type: categories
-                - id: '5'
+                - id: '18'
                   type: indicators
                   attributes:
                     name: cum
@@ -847,9 +922,9 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '11'
+                        id: '38'
                         type: categories
-                - id: '6'
+                - id: '19'
                   type: indicators
                   attributes:
                     name: molestiae
@@ -863,10 +938,10 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '12'
+                        id: '39'
                         type: categories
                 included:
-                - id: '10'
+                - id: '37'
                   type: categories
                   attributes:
                     name: voluptatem
@@ -876,9 +951,9 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '4'
+                      - id: '17'
                         type: indicators
-                - id: '11'
+                - id: '38'
                   type: categories
                   attributes:
                     name: cum
@@ -888,9 +963,9 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '5'
+                      - id: '18'
                         type: indicators
-                - id: '12'
+                - id: '39'
                   type: categories
                   attributes:
                     name: molestiae
@@ -900,7 +975,7 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '6'
+                      - id: '19'
                         type: indicators
                 meta:
                   total_indicators: 3
@@ -923,65 +998,65 @@ paths:
             application/json:
               example:
                 data:
-                - id: '4'
+                - id: '89'
                   type: journeys
                   attributes:
                     title: Enim repellat pariatur est.
                     subtitle: Enim repellat pariatur est.
                     theme: Enim repellat pariatur est.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBFUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b45972579a6eccb46a6834fba5116f9272754581/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc0FCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2fc612de70b806898c9cf47cd26ceb21a256d653/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc0FCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2fc612de70b806898c9cf47cd26ceb21a256d653/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc0FCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2fc612de70b806898c9cf47cd26ceb21a256d653/picture.jpg
                     credits: Enim repellat pariatur est.
                     credits_url: http://kutch-spencer.com/moises
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '7'
+                      - id: '200'
                         type: journey_steps
-                      - id: '8'
+                      - id: '201'
                         type: journey_steps
-                - id: '5'
+                - id: '90'
                   type: journeys
                   attributes:
                     title: Placeat commodi libero et.
                     subtitle: Placeat commodi libero et.
                     theme: Placeat commodi libero et.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2e51a41db29a691c77a553342386811502c3480/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc01CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b4acac7113e88900c8a7fdaa36814e84a5131764/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc01CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b4acac7113e88900c8a7fdaa36814e84a5131764/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc01CIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b4acac7113e88900c8a7fdaa36814e84a5131764/picture.jpg
                     credits: Placeat commodi libero et.
                     credits_url: http://bartoletti.com/jeremiah_cronin
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '9'
+                      - id: '202'
                         type: journey_steps
-                      - id: '10'
+                      - id: '203'
                         type: journey_steps
-                - id: '6'
+                - id: '91'
                   type: journeys
                   attributes:
                     title: Et quaerat omnis veniam.
                     subtitle: Et quaerat omnis veniam.
                     theme: Et quaerat omnis veniam.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBGdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--560f7f55efa5d348f3ba2f3cd0a4ff9ccbf5b4d1/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc1lCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8ee82406f581e1257514d8a03120158155fa1a00/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc1lCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8ee82406f581e1257514d8a03120158155fa1a00/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBc1lCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8ee82406f581e1257514d8a03120158155fa1a00/picture.jpg
                     credits: Et quaerat omnis veniam.
                     credits_url: http://hane.com/jules
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '12'
+                      - id: '205'
                         type: journey_steps
-                      - id: '11'
+                      - id: '204'
                         type: journey_steps
                 meta:
                   total: 3
@@ -1020,32 +1095,32 @@ paths:
             application/json:
               example:
                 data:
-                  id: '25'
+                  id: '110'
                   type: journeys
                   attributes:
                     title: Autem et et ex.
                     subtitle: Autem et et ex.
                     theme: Autem et et ex.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d7ccbbcb3a34a40dd42a727be3c14d844061aa7d/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ1VDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d37f11adb2e746578cd6c8f47b4b1d3a40dcb150/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ1VDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d37f11adb2e746578cd6c8f47b4b1d3a40dcb150/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ1VDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d37f11adb2e746578cd6c8f47b4b1d3a40dcb150/picture.jpg
                     credits: Autem et et ex.
                     credits_url: http://jacobson.biz/everett
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '50'
+                      - id: '243'
                         type: journey_steps
-                      - id: '47'
+                      - id: '240'
                         type: journey_steps
-                      - id: '56'
+                      - id: '249'
                         type: journey_steps
-                      - id: '53'
+                      - id: '246'
                         type: journey_steps
                 included:
-                - id: '50'
+                - id: '243'
                   type: journey_steps
                   attributes:
                     step_type: conclusion
@@ -1058,10 +1133,10 @@ paths:
                     credits_url: http://keebler.info/daine
                     background_color: "#c2e0e0"
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBUUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--27138d7d10dfd59e9a762e2dc09e4b573ccb6c6b/picture.jpg
-                - id: '47'
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdndCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aca37815e26e0834ae9fd8be7bd62be7c66211c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdndCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aca37815e26e0834ae9fd8be7bd62be7c66211c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdndCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aca37815e26e0834ae9fd8be7bd62be7c66211c/picture.jpg
+                - id: '240'
                   type: journey_steps
                   attributes:
                     step_type: landing
@@ -1071,10 +1146,10 @@ paths:
                     credits: Et quaerat omnis veniam.
                     credits_url: http://hane.com/jules
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBTUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--093feffe581362132535baa8401eadfdf9033863/picture.jpg
-                - id: '56'
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdmdCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aa5740d505f9b2defdf12b8bfb546611f4d9233/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdmdCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aa5740d505f9b2defdf12b8bfb546611f4d9233/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdmdCIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0aa5740d505f9b2defdf12b8bfb546611f4d9233/picture.jpg
+                - id: '249'
                   type: journey_steps
                   attributes:
                     step_type: embed
@@ -1087,7 +1162,7 @@ paths:
                     mask_sql: Eum consequuntur adipisci non.
                     map_url: http://lind.name/alana
                     embedded_map_url: http://lind.name/alana
-                - id: '53'
+                - id: '246'
                   type: journey_steps
                   attributes:
                     step_type: chapter
@@ -1097,10 +1172,11 @@ paths:
                     chapter_number: 93
                     credits: Impedit animi eveniet numquam.
                     credits_url: http://ritchie.com/jame
+                    background_color: "#bf40bf"
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBVUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b901a2be846ccb323dcc92b5007079add7856e34/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ0FDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0632b52445d831b942da67dc667fe8769c5da7f0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ0FDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0632b52445d831b942da67dc667fe8769c5da7f0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZ0FDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0632b52445d831b942da67dc667fe8769c5da7f0/picture.jpg
   "/api/layer-groups":
     get:
       summary: Get list of layer groups
@@ -1126,7 +1202,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '5'
+                - id: '46'
                   type: layer_groups
                   attributes:
                     name: voluptatem
@@ -1142,7 +1218,7 @@ paths:
                   relationships:
                     super_group:
                       data:
-                - id: '6'
+                - id: '47'
                   type: layer_groups
                   attributes:
                     name: cum
@@ -1159,7 +1235,7 @@ paths:
                   relationships:
                     super_group:
                       data:
-                - id: '7'
+                - id: '48'
                   type: layer_groups
                   attributes:
                     name: molestiae
@@ -1202,95 +1278,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '27'
-                  type: layers
-                  attributes:
-                    name: voluptatem
-                    slug: Layer-1
-                    layer_type:
-                    zindex: 38
-                    opacity: 38.0
-                    active:
-                    order: 38
-                    dashboard_order: 38
-                    color:
-                    info:
-                    interactivity:
-                    css: Enim repellat pariatur est.
-                    query: Enim repellat pariatur est.
-                    layer_config: '38'
-                    layer_provider: cog
-                    published: true
-                    locate_layer: false
-                    icon_class:
-                    legend: Enim repellat pariatur est.
-                    zoom_max: 38
-                    zoom_min: 38
-                    download: false
-                    dataset_shortname:
-                    dataset_source_url:
-                    analysis_suitable: true
-                    analysis_query: Enim repellat pariatur est.
-                    analysis_body: Enim repellat pariatur est.
-                    interaction_config: Enim repellat pariatur est.
-                  relationships:
-                    layer_group:
-                      data:
-                        id: '14'
-                        type: layer_groups
-                    sources:
-                      data: []
-                    agrupation:
-                      data:
-                        id: 4
-                        layer_id: 27
-                        layer_group_id: 14
-                        active: false
-                - id: '28'
-                  type: layers
-                  attributes:
-                    name: cum
-                    slug: Layer-2
-                    layer_type:
-                    zindex: 41
-                    opacity: 41.0
-                    active:
-                    order: 41
-                    dashboard_order: 41
-                    color:
-                    info:
-                    interactivity:
-                    css: Placeat commodi libero et.
-                    query: Placeat commodi libero et.
-                    layer_config: '41'
-                    layer_provider: cartodb
-                    published: true
-                    locate_layer: false
-                    icon_class:
-                    legend: Placeat commodi libero et.
-                    zoom_max: 41
-                    zoom_min: 41
-                    download: false
-                    dataset_shortname:
-                    dataset_source_url:
-                    analysis_suitable: true
-                    analysis_query: Placeat commodi libero et.
-                    analysis_body: Placeat commodi libero et.
-                    interaction_config: Placeat commodi libero et.
-                  relationships:
-                    layer_group:
-                      data:
-                        id: '14'
-                        type: layer_groups
-                    sources:
-                      data: []
-                    agrupation:
-                      data:
-                        id: 5
-                        layer_id: 28
-                        layer_group_id: 14
-                        active: false
-                - id: '29'
+                - id: '93'
                   type: layers
                   attributes:
                     name: molestiae
@@ -1324,15 +1312,103 @@ paths:
                   relationships:
                     layer_group:
                       data:
-                        id: '14'
+                        id: '55'
                         type: layer_groups
                     sources:
                       data: []
                     agrupation:
                       data:
-                        id: 6
-                        layer_id: 29
-                        layer_group_id: 14
+                        id: 32
+                        layer_id: 93
+                        layer_group_id: 55
+                        active: false
+                - id: '91'
+                  type: layers
+                  attributes:
+                    name: voluptatem
+                    slug: Layer-1
+                    layer_type:
+                    zindex: 38
+                    opacity: 38.0
+                    active:
+                    order: 38
+                    dashboard_order: 38
+                    color:
+                    info:
+                    interactivity:
+                    css: Enim repellat pariatur est.
+                    query: Enim repellat pariatur est.
+                    layer_config: '38'
+                    layer_provider: cog
+                    published: true
+                    locate_layer: false
+                    icon_class:
+                    legend: Enim repellat pariatur est.
+                    zoom_max: 38
+                    zoom_min: 38
+                    download: false
+                    dataset_shortname:
+                    dataset_source_url:
+                    analysis_suitable: true
+                    analysis_query: Enim repellat pariatur est.
+                    analysis_body: Enim repellat pariatur est.
+                    interaction_config: Enim repellat pariatur est.
+                  relationships:
+                    layer_group:
+                      data:
+                        id: '55'
+                        type: layer_groups
+                    sources:
+                      data: []
+                    agrupation:
+                      data:
+                        id: 30
+                        layer_id: 91
+                        layer_group_id: 55
+                        active: false
+                - id: '92'
+                  type: layers
+                  attributes:
+                    name: cum
+                    slug: Layer-2
+                    layer_type:
+                    zindex: 41
+                    opacity: 41.0
+                    active:
+                    order: 41
+                    dashboard_order: 41
+                    color:
+                    info:
+                    interactivity:
+                    css: Placeat commodi libero et.
+                    query: Placeat commodi libero et.
+                    layer_config: '41'
+                    layer_provider: cartodb
+                    published: true
+                    locate_layer: false
+                    icon_class:
+                    legend: Placeat commodi libero et.
+                    zoom_max: 41
+                    zoom_min: 41
+                    download: false
+                    dataset_shortname:
+                    dataset_source_url:
+                    analysis_suitable: true
+                    analysis_query: Placeat commodi libero et.
+                    analysis_body: Placeat commodi libero et.
+                    interaction_config: Placeat commodi libero et.
+                  relationships:
+                    layer_group:
+                      data:
+                        id: '55'
+                        type: layer_groups
+                    sources:
+                      data: []
+                    agrupation:
+                      data:
+                        id: 31
+                        layer_id: 92
+                        layer_group_id: 55
                         active: false
                 meta:
                   total_layers: 3
@@ -1388,21 +1464,21 @@ paths:
             application/json:
               example:
                 data:
-                - id: '4'
+                - id: '17'
                   type: map_menu_entries
                   attributes:
                     label: Otha Kemmer
                     link: http://kutch-spencer.com/moises
                     position: 38
                     ancestry:
-                - id: '5'
+                - id: '18'
                   type: map_menu_entries
                   attributes:
                     label: Msgr. Genaro Cronin
                     link: http://bartoletti.com/jeremiah_cronin
                     position: 41
                     ancestry:
-                - id: '6'
+                - id: '19'
                   type: map_menu_entries
                   attributes:
                     label: Raymon Wisoky
@@ -1434,7 +1510,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '5'
+                - id: '24'
                   type: models
                   attributes:
                     name: voluptatem
@@ -1450,7 +1526,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '6'
+                - id: '25'
                   type: models
                   attributes:
                     name: cum
@@ -1466,7 +1542,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '7'
+                - id: '26'
                   type: models
                   attributes:
                     name: molestiae
@@ -1482,7 +1558,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '8'
+                - id: '27'
                   type: models
                   attributes:
                     name: quos
@@ -1606,12 +1682,12 @@ paths:
           content:
             application/json:
               example:
-                id: 2
-                image_data: '{"id":"106cf13e74f3725bbfd9821dd727dcfa.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
-                created_at: '2023-04-03T08:35:15.640+02:00'
-                updated_at: '2023-04-03T08:35:15.642+02:00'
-                url: "/uploads/store/106cf13e74f3725bbfd9821dd727dcfa.jpg"
-                image_url: "/uploads/store/106cf13e74f3725bbfd9821dd727dcfa.jpg"
+                id: 4
+                image_data: '{"id":"6a377de11e75adc732a6fbb66f9bf465.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
+                created_at: '2023-04-05T16:04:28.213+02:00'
+                updated_at: '2023-04-05T16:04:28.215+02:00'
+                url: "/uploads/store/6a377de11e75adc732a6fbb66f9bf465.jpg"
+                image_url: "/uploads/store/6a377de11e75adc732a6fbb66f9bf465.jpg"
         '401':
           description: Authentication failed
           content:
@@ -1695,7 +1771,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: '2'
+                  id: '6'
                   type: share_urls
                   attributes:
                     uid: '12345'
@@ -1717,7 +1793,7 @@ paths:
           content:
             application/json:
               example:
-                uid: f3b9840b1188ae5f6bd4
+                uid: e5f010fc3a7e522d8a6a
   "/api/sites":
     get:
       summary: Get list of all site scopes
@@ -1828,10 +1904,10 @@ paths:
                   relationships:
                     site_pages:
                       data:
-                      - id: '2'
+                      - id: '11'
                         type: site_pages
                 included:
-                - id: '2'
+                - id: '11'
                   type: site_pages
                   attributes:
                     title: voluptatem
@@ -1858,10 +1934,10 @@ paths:
           content:
             application/json:
               example:
-                id: 7
+                id: 30
                 email: person-1@example.com
-                created_at: '2023-04-03T08:35:15.817+02:00'
-                updated_at: '2023-04-03T08:35:15.817+02:00'
+                created_at: '2023-04-05T16:04:28.365+02:00'
+                updated_at: '2023-04-05T16:04:28.365+02:00'
                 first_name: Dawna
                 last_name: Block
                 phone: "(995) 001-7692 x452"
@@ -1891,9 +1967,9 @@ paths:
                 first_name: Jan
                 last_name: Kowalski
                 email: jankowalski@example.com
-                id: 9
-                created_at: '2023-04-03T08:35:15.847+02:00'
-                updated_at: '2023-04-03T08:35:15.856+02:00'
+                id: 32
+                created_at: '2023-04-05T16:04:28.392+02:00'
+                updated_at: '2023-04-05T16:04:28.400+02:00'
                 phone: "(995) 001-7692 x452"
                 organization: voluptatem
                 organization_role: voluptatem


### PR DESCRIPTION
Adding all features required to support Homepages:
 - new Homepage model that keeps basic information about homepage
 - new HomepageJourney model that stores info about journeys shown at Homepage
 - new HomepageSection model which saves information about every individual section under journey section
 - integration with Admin which allows to create/update/delete Homepages
 - adding new API endpoint which allows to get Homepage for appropriate subdomain

## Testing instructions

I think the simplest way how to test this manually is to:
 - login to Admin and create new Homepage (add info about journeys and at least one section)
 - go to swagger doc and get homepage data via API. Check that data corresponds to data which you have used when creating new homepage

## Tracking

https://vizzuality.atlassian.net/browse/RA2-139
https://vizzuality.atlassian.net/browse/RA2-140
https://vizzuality.atlassian.net/browse/RA2-141
https://vizzuality.atlassian.net/browse/RA2-142
https://vizzuality.atlassian.net/browse/RA2-143