### PR TITLE
feat: BE models and administration for static pages (About page)

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/martintomas/activeadmin-globalize.git
-  revision: a939ef6cc910ef089b948ec60a91b32f4f3b4288
+  revision: 1b1128f4f91171689cc3dd1ff390bff4ce2e8895
   branch: main
   specs:
     activeadmin-globalize (0.9.10)

--- a/backend/app/admin/static_page.rb
+++ b/backend/app/admin/static_page.rb
@@ -1,0 +1,97 @@
+ActiveAdmin.register StaticPage::Base do
+  includes :translations
+
+  permit_params :slug, :image, :image_credits_url,
+    translations_attributes: [:id, :locale, :title, :image_credits, :_destroy],
+    sections_attributes: [:id, :slug, :title_size, :show_at_navigation, :section_type, :position, :_destroy,
+      translations_attributes: [:id, :locale, :title, :_destroy],
+      section_paragraph_attributes: [:id, :image, :image_position, :image_credits_url, :position, :_destroy, translations_attributes: [:id, :locale, :text, :image_credits, :_destroy]],
+      section_items_attributes: [:id, :image, :position, :_destroy, translations_attributes: [:id, :locale, :title, :description, :_destroy]],
+      section_references_attributes: [:id, :slug, :position, :_destroy, translations_attributes: [:id, :locale, :text, :_destroy]]]
+
+  config.filters = false
+
+  controller do
+    after_save do |resource|
+      resource.sections.each do |section|
+        section.section_paragraph.destroy unless section.section_type == "paragraph"
+        section.section_items.destroy_all unless section.section_type == "items"
+        section.section_references.destroy_all unless section.section_type == "references"
+      end
+    end
+  end
+
+  index do
+    id_column
+    column :slug
+    column :title
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :slug
+      row :title
+      row :image do |record|
+        render "admin/shared/preview", blob: record.image if record.image.present?
+      end
+      row :image_credits
+      row :image_credits_url
+    end
+
+    panel "Sections" do
+      resource.sections.order(:position).each do |section|
+        panel section.title do
+          attributes_table_for section do
+            row :id
+            row :slug
+            row :title
+            row :title_size
+            row :show_at_navigation
+            if section.section_type == "paragraph"
+              attributes_table_for section.section_paragraph do
+                row :image do |record|
+                  render "admin/shared/preview", blob: record.image if record.image.present?
+                end
+                row :image_position
+                row :image_credits
+                row :image_credits_url
+                row :text do |record|
+                  ActionText::Content.new(record.text)
+                end
+              end
+            elsif section.section_type == "items"
+              panel "Items" do
+                section.section_items.order(:position).each do |item|
+                  attributes_table_for item do
+                    row :image do |record|
+                      render "admin/shared/preview", blob: record.image if record.image.present?
+                    end
+                    row :title
+                    row :description do |record|
+                      ActionText::Content.new(record.description)
+                    end
+                  end
+                end
+              end
+            elsif section.section_type == "references"
+              panel "References" do
+                section.section_references.order(:position).each do |reference|
+                  attributes_table_for reference do
+                    row :slug
+                    row :text do |record|
+                      ActionText::Content.new(record.text)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  form partial: "form"
+end

--- a/backend/app/assets/stylesheets/active_admin.css.scss
+++ b/backend/app/assets/stylesheets/active_admin.css.scss
@@ -49,6 +49,13 @@ div#footer{display: none;}
     list-style-type: decimal !important;
   }
 }
+
+.trix-toolbar-disable-attachment {
+  .trix-button-group--file-tools {
+    display: none;
+  }
+}
+
 .use-simple-trix-toolbar {
   .trix-button--icon-code {
     display: none;

--- a/backend/app/javascript/admin/has_many_collapsable.js
+++ b/backend/app/javascript/admin/has_many_collapsable.js
@@ -7,19 +7,19 @@ function initHasManySections() {
 
 // Enable collapsing for newly added has_many Admin sections
 // Also updates legend of newly added section and automatically uncollapses this one
-function updateLastHasManyContainer() {
-    let $lastContainer = $("a.button.has_many_remove").last().closest("fieldset.has_many_fields");
-    attachHasManySectionToggleListener($lastContainer);
-    $lastContainer.find("div.has-many-section").removeClass("section-hidden");
+function updateLastHasManyContainer(event, container) {
+    let $container = $(container)
+    attachHasManySectionToggleListener($container);
+    $container.find("div.has-many-section").removeClass("section-hidden");
 }
 
 // Attach listener which will toggle visibility of section
 function attachHasManySectionToggleListener(container) {
-    container.find(".has-many-toggle-collapse legend").click((event) => {
+    container.find(".has-many-toggle-collapse legend").first().click((event) => {
         let $target = $(event.target);
-        $target.closest("fieldset.has_many_fields").find("div.has-many-section").toggleClass("section-hidden");
+        $target.closest("fieldset.has_many_fields").find("div.has-many-section").first().toggleClass("section-hidden");
     });
 }
 
 $(document).ready(initHasManySections);
-$(document).on("has_many_add:after", ".has_many_container", updateLastHasManyContainer);
+$(document).on("has_many_add:after", updateLastHasManyContainer);

--- a/backend/app/models/homepage_section.rb
+++ b/backend/app/models/homepage_section.rb
@@ -21,7 +21,7 @@ class HomepageSection < ApplicationRecord
 
   has_one_attached :image, service: :local_public
 
-  enum :image_position, {left: "left", right: "right", cover: "cover"}, default: :left, _prefix: :image_position
+  enum :image_position, {left: "left", right: "right", cover: "cover"}, default: :left, prefix: true
 
   translates :title, :subtitle, :button_text, :image_credits, touch: true, fallbacks_for_empty_translations: true
   active_admin_translates :title, :subtitle, :button_text, :image_credits

--- a/backend/app/models/static_page.rb
+++ b/backend/app/models/static_page.rb
@@ -1,0 +1,5 @@
+module StaticPage
+  def self.table_name_prefix
+    "static_page_"
+  end
+end

--- a/backend/app/models/static_page/base.rb
+++ b/backend/app/models/static_page/base.rb
@@ -1,0 +1,19 @@
+module StaticPage
+  class Base < ApplicationRecord
+    has_many :sections, class_name: "StaticPage::Section", foreign_key: "static_page_id", inverse_of: :static_page, dependent: :destroy
+
+    has_one_attached :image, service: :local_public
+
+    translates :title, :image_credits, touch: true, fallbacks_for_empty_translations: true
+    active_admin_translates :title, :image_credits
+
+    translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+
+    validates_presence_of :slug
+    validates_uniqueness_of :slug
+    validates :image_credits_url, url: true
+    validates :image, presence: true, content_type: /\Aimage\/.*\z/
+
+    accepts_nested_attributes_for :sections, allow_destroy: true
+  end
+end

--- a/backend/app/models/static_page/section.rb
+++ b/backend/app/models/static_page/section.rb
@@ -1,0 +1,23 @@
+module StaticPage
+  class Section < ApplicationRecord
+    belongs_to :static_page, class_name: "StaticPage::Base", inverse_of: :sections
+    has_one :section_paragraph, class_name: "StaticPage::SectionParagraph", dependent: :destroy
+    has_many :section_items, class_name: "StaticPage::SectionItem", dependent: :destroy
+    has_many :section_references, class_name: "StaticPage::SectionReference", dependent: :destroy
+
+    enum :section_type, {paragraph: "paragraph", items: "items", references: "references"}, default: :paragraph, prefix: true
+
+    translates :title, touch: true, fallbacks_for_empty_translations: true
+    active_admin_translates :title
+
+    translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+
+    validates_presence_of :position, :section_type
+    validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+    validates :show_at_navigation, inclusion: {in: [true, false]}
+
+    accepts_nested_attributes_for :section_paragraph, allow_destroy: true
+    accepts_nested_attributes_for :section_items, allow_destroy: true
+    accepts_nested_attributes_for :section_references, allow_destroy: true
+  end
+end

--- a/backend/app/models/static_page/section_item.rb
+++ b/backend/app/models/static_page/section_item.rb
@@ -1,0 +1,18 @@
+module StaticPage
+  class SectionItem < ApplicationRecord
+    belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_items
+
+    has_one_attached :image, service: :local_public
+
+    has_rich_text :description
+
+    translates :title, :description, touch: true, fallbacks_for_empty_translations: true
+    active_admin_translates :title, :description
+
+    translation_class.validates_presence_of :title, if: -> { locale.to_s == I18n.default_locale.to_s }
+
+    validates_presence_of :position
+    validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+    validates :image, content_type: /\Aimage\/.*\z/
+  end
+end

--- a/backend/app/models/static_page/section_paragraph.rb
+++ b/backend/app/models/static_page/section_paragraph.rb
@@ -1,0 +1,17 @@
+module StaticPage
+  class SectionParagraph < ApplicationRecord
+    belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_paragraph
+
+    has_one_attached :image, service: :local_public
+
+    has_rich_text :text
+
+    enum :image_position, {left: "left", right: "right"}, default: :right, prefix: true
+
+    translates :text, :image_credits, touch: true, fallbacks_for_empty_translations: true
+    active_admin_translates :text, :image_credits
+
+    validates :image_credits_url, url: true
+    validates :image, content_type: /\Aimage\/.*\z/
+  end
+end

--- a/backend/app/models/static_page/section_reference.rb
+++ b/backend/app/models/static_page/section_reference.rb
@@ -1,0 +1,13 @@
+module StaticPage
+  class SectionReference < ApplicationRecord
+    belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_references
+
+    has_rich_text :text
+
+    translates :text, touch: true, fallbacks_for_empty_translations: true
+    active_admin_translates :text
+
+    validates_presence_of :position
+    validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  end
+end

--- a/backend/app/views/admin/homepages/_form.html.slim
+++ b/backend/app/views/admin/homepages/_form.html.slim
@@ -43,4 +43,6 @@
             - ff.input :background_color
           - unless ff.object.new_record?
             - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")
-  = f.actions
+  = f.actions do
+    = f.action :submit
+    = f.cancel_link

--- a/backend/app/views/admin/journeys/_form.html.slim
+++ b/backend/app/views/admin/journeys/_form.html.slim
@@ -54,5 +54,7 @@
           - unless ff.object.new_record?
             - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")
 
-  = f.actions
+  = f.actions do
+    = f.action :submit
+    = f.cancel_link
 

--- a/backend/app/views/admin/layers/_form.html.slim
+++ b/backend/app/views/admin/layers/_form.html.slim
@@ -34,4 +34,6 @@
       = f.input :analysis_body, wrapper_html: {class: "analysis-query-input"}
     = f.inputs "Dashboard"
       = f.input :dashboard_order
-  = f.actions
+  = f.actions do
+    = f.action :submit
+    = f.cancel_link

--- a/backend/app/views/admin/site_pages/_form.html.slim
+++ b/backend/app/views/admin/site_pages/_form.html.slim
@@ -12,4 +12,6 @@
     = f.input :site_scope
     = f.input :priority
     = f.input :slug
-  = f.actions
+  = f.actions do
+    = f.action :submit
+    = f.cancel_link

--- a/backend/app/views/admin/static_page_bases/_form.html.slim
+++ b/backend/app/views/admin/static_page_bases/_form.html.slim
@@ -1,0 +1,39 @@
+= semantic_form_for [:admin, resource], builder: ActiveAdmin::FormBuilder do |f|
+  = f.semantic_errors :base
+  = f.inputs "Translated fields" do
+    = f.translated_inputs switch_locale: false do |ff|
+      = ff.input :id, as: :hidden
+      = ff.input :locale, as: :hidden
+      = ff.input :title
+      = ff.input :image_credits
+  = f.inputs "Common fields" do
+    = f.input :slug
+    == render "admin/shared/image_with_thumbnail", blob: :image, f: f
+    = f.input :image_credits_url
+
+  = f.inputs "Sections", class: "inputs has-many-collapsed" do
+    - f.has_many :sections, heading: false, sortable: :position, sortable_start: 1 do |ff|
+      = ff.semantic_errors
+      = ff.inputs (ff.object.new_record? ? "New Section" : ff.object.title.to_s), class: "inputs has-many-toggle-collapse" do
+        div class="has-many-section section-hidden"
+          = ff.inputs "Translated fields" do
+            - ff.translated_inputs switch_locale: false do |fff|
+              - fff.input :id, as: :hidden
+              - fff.input :locale, as: :hidden
+              - fff.input :title
+          = ff.inputs "Common fields" do
+            - ff.input :slug
+            - ff.input :title_size
+            - ff.input :show_at_navigation
+          = ff.inputs "Section specific data" do
+            div class="select-dependency-container"
+              - ff.input :section_type, as: :select, collection: StaticPage::Section.section_types.keys, input_html: {class: "select-dependency-controller"}
+              div class="select-dependency-field trix-toolbar-disable-attachment" style="margin: 10px;" data-available-for=["paragraph"]
+                == render "section_paragraph", f: ff
+              div class="select-dependency-field has-many-collapsed" style="margin: 10px;" data-available-for=["items"]
+                == render "section_items", f: ff
+              div class="select-dependency-field has-many-collapsed" style="margin: 10px;" data-available-for=["references"]
+                == render "section_references", f: ff
+          - unless ff.object.new_record?
+            - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")
+  = f.actions

--- a/backend/app/views/admin/static_page_bases/_form.html.slim
+++ b/backend/app/views/admin/static_page_bases/_form.html.slim
@@ -36,4 +36,6 @@
                 == render "section_references", f: ff
           - unless ff.object.new_record?
             - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")
-  = f.actions
+  = f.actions do
+    = f.action :submit
+    = f.cancel_link

--- a/backend/app/views/admin/static_page_bases/_section_items.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_items.html.slim
@@ -7,6 +7,7 @@
           - fff.input :id, as: :hidden
           - fff.input :locale, as: :hidden
           - fff.input :title
-          = fff.rich_text_area :description
+          = fff.inputs "Description" do
+            = fff.rich_text_area :description
       = ff.inputs "Common fields" do
         == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, inside_has_many_block: true

--- a/backend/app/views/admin/static_page_bases/_section_items.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_items.html.slim
@@ -1,0 +1,12 @@
+- f.has_many :section_items, heading: false, sortable: :position, sortable_start: 1 do |ff|
+  = ff.semantic_errors
+  = ff.inputs (ff.object.new_record? ? "New Section Item" : ff.object.title.to_s), class: "inputs has-many-toggle-collapse" do
+    div class="has-many-section section-hidden use-simple-trix-toolbar"
+      = ff.inputs "Translated fields" do
+        - ff.translated_inputs switch_locale: false do |fff|
+          - fff.input :id, as: :hidden
+          - fff.input :locale, as: :hidden
+          - fff.input :title
+          = fff.rich_text_area :description
+      = ff.inputs "Common fields" do
+        == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, inside_has_many_block: true

--- a/backend/app/views/admin/static_page_bases/_section_items.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_items.html.slim
@@ -11,3 +11,5 @@
             = fff.rich_text_area :description
       = ff.inputs "Common fields" do
         == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, inside_has_many_block: true
+      - unless ff.object.new_record?
+        - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")

--- a/backend/app/views/admin/static_page_bases/_section_paragraph.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_paragraph.html.slim
@@ -5,7 +5,8 @@
       - fff.input :id, as: :hidden
       - fff.input :locale, as: :hidden
       - fff.input :image_credits
-      = fff.rich_text_area :text
+      = fff.inputs "Text" do
+        = fff.rich_text_area :text
   = ff.inputs "Common fields" do
     == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, required: true, inside_has_many_block: true
     - ff.input :image_position, as: :select, collection: StaticPage::SectionParagraph.image_positions.keys

--- a/backend/app/views/admin/static_page_bases/_section_paragraph.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_paragraph.html.slim
@@ -1,0 +1,12 @@
+= f.semantic_fields_for :section_paragraph, f.object.section_paragraph || f.object.build_section_paragraph do |ff|
+  = ff.semantic_errors
+  = ff.inputs "Translated fields" do
+    - ff.translated_inputs switch_locale: false do |fff|
+      - fff.input :id, as: :hidden
+      - fff.input :locale, as: :hidden
+      - fff.input :image_credits
+      = fff.rich_text_area :text
+  = ff.inputs "Common fields" do
+    == render "admin/shared/image_with_thumbnail", blob: :image, f: ff, required: true, inside_has_many_block: true
+    - ff.input :image_position, as: :select, collection: StaticPage::SectionParagraph.image_positions.keys
+    - ff.input :image_credits_url

--- a/backend/app/views/admin/static_page_bases/_section_references.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_references.html.slim
@@ -1,6 +1,6 @@
 - f.has_many :section_references, heading: false, sortable: :position, sortable_start: 1 do |ff|
   = ff.semantic_errors
-  = ff.inputs (ff.object.new_record? ? "New Section Reference" : ff.object.slug.to_s), class: "inputs has-many-toggle-collapse" do
+  = ff.inputs ((ff.object.new_record? ? "New Section Reference" : ff.object.slug.to_s).presence || "Reference Without Slug"), class: "inputs has-many-toggle-collapse" do
     div class="has-many-section section-hidden use-simple-trix-toolbar"
       = ff.inputs "Translated fields" do
         - ff.translated_inputs switch_locale: false do |fff|
@@ -10,3 +10,5 @@
             = fff.rich_text_area :text
       = ff.inputs "Common fields" do
         - ff.input :slug
+      - unless ff.object.new_record?
+        - ff.input :_destroy, as: :boolean, wrapper_html: { class: "has_many_delete" }, label: I18n.t("active_admin.has_many_delete")

--- a/backend/app/views/admin/static_page_bases/_section_references.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_references.html.slim
@@ -1,0 +1,11 @@
+- f.has_many :section_references, heading: false, sortable: :position, sortable_start: 1 do |ff|
+  = ff.semantic_errors
+  = ff.inputs (ff.object.new_record? ? "New Section Reference" : ff.object.slug.to_s), class: "inputs has-many-toggle-collapse" do
+    div class="has-many-section section-hidden use-simple-trix-toolbar"
+      = ff.inputs "Translated fields" do
+        - ff.translated_inputs switch_locale: false do |fff|
+          - fff.input :id, as: :hidden
+          - fff.input :locale, as: :hidden
+          = fff.rich_text_area :text
+      = ff.inputs "Common fields" do
+        - ff.input :slug

--- a/backend/app/views/admin/static_page_bases/_section_references.html.slim
+++ b/backend/app/views/admin/static_page_bases/_section_references.html.slim
@@ -6,6 +6,7 @@
         - ff.translated_inputs switch_locale: false do |fff|
           - fff.input :id, as: :hidden
           - fff.input :locale, as: :hidden
-          = fff.rich_text_area :text
+          = fff.inputs "Text" do
+            = fff.rich_text_area :text
       = ff.inputs "Common fields" do
         - ff.input :slug

--- a/backend/config/initializers/inflections.rb
+++ b/backend/config/initializers/inflections.rb
@@ -3,12 +3,12 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular "base", "bases"
+  #   inflect.singular /^(ox)en/i, '\1'
+  #   inflect.irregular 'person', 'people'
+  #   inflect.uncountable %w( fish sheep )
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -1,23 +1,9 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    models:
+      static_page_base:
+        one: Static Page
+        other: Static Pages
+      static_page/base:
+        one: Static Page
+        other: Static Pages

--- a/backend/db/migrate/20230413084830_create_static_page_bases.rb
+++ b/backend/db/migrate/20230413084830_create_static_page_bases.rb
@@ -1,0 +1,20 @@
+class CreateStaticPageBases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :static_page_bases do |t|
+      t.string :slug, null: false, index: {unique: true}
+      t.string :image_credits_url
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        StaticPage::Base.create_translation_table! title: :string, image_credits: :string
+      end
+
+      dir.down do
+        StaticPage::Base.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230413085620_create_static_page_sections.rb
+++ b/backend/db/migrate/20230413085620_create_static_page_sections.rb
@@ -1,0 +1,24 @@
+class CreateStaticPageSections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :static_page_sections do |t|
+      t.belongs_to :static_page, null: false, foreign_key: {on_delete: :cascade, to_table: :static_page_bases}
+      t.integer :position, null: false
+      t.string :slug
+      t.string :section_type, null: false
+      t.integer :title_size, default: 2
+      t.boolean :show_at_navigation, null: false, default: false
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        StaticPage::Section.create_translation_table! title: :string
+      end
+
+      dir.down do
+        StaticPage::Section.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230413095128_create_static_page_section_items.rb
+++ b/backend/db/migrate/20230413095128_create_static_page_section_items.rb
@@ -1,0 +1,20 @@
+class CreateStaticPageSectionItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :static_page_section_items do |t|
+      t.belongs_to :section, null: false, foreign_key: {on_delete: :cascade, to_table: :static_page_sections}
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        StaticPage::SectionItem.create_translation_table! title: :string, description: :text
+      end
+
+      dir.down do
+        StaticPage::SectionItem.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230413153128_create_static_page_section_paragraphs.rb
+++ b/backend/db/migrate/20230413153128_create_static_page_section_paragraphs.rb
@@ -1,0 +1,21 @@
+class CreateStaticPageSectionParagraphs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :static_page_section_paragraphs do |t|
+      t.belongs_to :section, null: false, foreign_key: {on_delete: :cascade, to_table: :static_page_sections}
+      t.string :image_position, null: false
+      t.string :image_credits_url
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        StaticPage::SectionParagraph.create_translation_table! text: :text, image_credits: :string
+      end
+
+      dir.down do
+        StaticPage::SectionParagraph.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/migrate/20230413154821_create_static_page_section_references.rb
+++ b/backend/db/migrate/20230413154821_create_static_page_section_references.rb
@@ -1,0 +1,21 @@
+class CreateStaticPageSectionReferences < ActiveRecord::Migration[7.0]
+  def change
+    create_table :static_page_section_references do |t|
+      t.belongs_to :section, null: false, foreign_key: {on_delete: :cascade, to_table: :static_page_sections}
+      t.string :slug
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        StaticPage::SectionReference.create_translation_table! text: :text
+      end
+
+      dir.down do
+        StaticPage::SectionReference.drop_translation_table!
+      end
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_154821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -509,6 +509,105 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
     t.text "license_url"
   end
 
+  create_table "static_page_base_translations", force: :cascade do |t|
+    t.bigint "static_page_base_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "image_credits"
+    t.index ["locale"], name: "index_static_page_base_translations_on_locale"
+    t.index ["static_page_base_id"], name: "index_static_page_base_translations_on_static_page_base_id"
+  end
+
+  create_table "static_page_bases", force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "image_credits_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_static_page_bases_on_slug", unique: true
+  end
+
+  create_table "static_page_section_item_translations", force: :cascade do |t|
+    t.bigint "static_page_section_item_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.text "description"
+    t.index ["locale"], name: "index_static_page_section_item_translations_on_locale"
+    t.index ["static_page_section_item_id"], name: "index_fa4aaafd643913512d32f726a2d5386348fe26b9"
+  end
+
+  create_table "static_page_section_items", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_static_page_section_items_on_section_id"
+  end
+
+  create_table "static_page_section_paragraph_translations", force: :cascade do |t|
+    t.bigint "static_page_section_paragraph_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "text"
+    t.string "image_credits"
+    t.index ["locale"], name: "index_static_page_section_paragraph_translations_on_locale"
+    t.index ["static_page_section_paragraph_id"], name: "index_f17c96ce33322e20078393ba2050031b69c21daa"
+  end
+
+  create_table "static_page_section_paragraphs", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.string "image_position", null: false
+    t.string "image_credits_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_static_page_section_paragraphs_on_section_id"
+  end
+
+  create_table "static_page_section_reference_translations", force: :cascade do |t|
+    t.bigint "static_page_section_reference_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "text"
+    t.index ["locale"], name: "index_static_page_section_reference_translations_on_locale"
+    t.index ["static_page_section_reference_id"], name: "index_20a5e4f35f4caac5967f343864093a95839d0632"
+  end
+
+  create_table "static_page_section_references", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.string "slug"
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_static_page_section_references_on_section_id"
+  end
+
+  create_table "static_page_section_translations", force: :cascade do |t|
+    t.bigint "static_page_section_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.index ["locale"], name: "index_static_page_section_translations_on_locale"
+    t.index ["static_page_section_id"], name: "index_5003c0227599fab8954262af0e37841ad7785126"
+  end
+
+  create_table "static_page_sections", force: :cascade do |t|
+    t.bigint "static_page_id", null: false
+    t.integer "position", null: false
+    t.string "slug"
+    t.string "section_type", null: false
+    t.integer "title_size", default: 2
+    t.boolean "show_at_navigation", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["static_page_id"], name: "index_static_page_sections_on_static_page_id"
+  end
+
   create_table "user_downloads", force: :cascade do |t|
     t.string "subdomain"
     t.integer "user_id"
@@ -551,4 +650,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_074139) do
   add_foreign_key "identities", "users"
   add_foreign_key "indicators", "categories"
   add_foreign_key "journey_steps", "journeys", on_delete: :cascade
+  add_foreign_key "static_page_section_items", "static_page_sections", column: "section_id", on_delete: :cascade
+  add_foreign_key "static_page_section_paragraphs", "static_page_sections", column: "section_id", on_delete: :cascade
+  add_foreign_key "static_page_section_references", "static_page_sections", column: "section_id", on_delete: :cascade
+  add_foreign_key "static_page_sections", "static_page_bases", column: "static_page_id", on_delete: :cascade
 end

--- a/backend/spec/factories/static_page/bases.rb
+++ b/backend/spec/factories/static_page/bases.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :static_page, class: "StaticPage::Base" do
+    sequence(:slug) { |n| "StaticPage-#{n}" }
+    sequence(:title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    sequence(:image_credits) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:image_credits_url) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+  end
+end

--- a/backend/spec/factories/static_page/section_items.rb
+++ b/backend/spec/factories/static_page/section_items.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :static_page_section_item, class: "StaticPage::SectionItem" do
+    section factory: :static_page_section
+    sequence(:title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:description) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.paragraph
+    end
+    image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    position { 1 }
+  end
+end

--- a/backend/spec/factories/static_page/section_paragraphs.rb
+++ b/backend/spec/factories/static_page/section_paragraphs.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :static_page_section_paragraph, class: "StaticPage::SectionParagraph" do
+    section factory: :static_page_section
+    sequence(:text) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.paragraph
+    end
+    image { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/picture.jpg"), "image/jpeg") }
+    sequence(:image_position) do |n|
+      StaticPage::SectionParagraph.image_positions.keys.sample random: Random.new(n)
+    end
+    sequence(:image_credits) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:image_credits_url) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Internet.url
+    end
+  end
+end

--- a/backend/spec/factories/static_page/section_references.rb
+++ b/backend/spec/factories/static_page/section_references.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :static_page_section_reference, class: "StaticPage::SectionReference" do
+    section factory: :static_page_section
+    sequence(:slug) { |n| "StaticPageReference-#{n}" }
+    sequence(:text) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.paragraph
+    end
+    position { 1 }
+  end
+end

--- a/backend/spec/factories/static_page/sections.rb
+++ b/backend/spec/factories/static_page/sections.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :static_page_section, class: "StaticPage::Section" do
+    static_page
+    position { 1 }
+    sequence(:slug) { |n| "StaticPageSection-#{n}" }
+    sequence(:section_type) do |n|
+      StaticPage::Section.section_types.keys.sample random: Random.new(n)
+    end
+    sequence(:title) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Lorem.sentence
+    end
+    sequence(:title_size) do |n|
+      (1..5).to_a.sample random: Random.new(n)
+    end
+    sequence(:show_at_navigation) do |n|
+      Faker::Config.random = Random.new(n)
+      Faker::Boolean.boolean
+    end
+  end
+end

--- a/backend/spec/models/static_page/base_spec.rb
+++ b/backend/spec/models/static_page/base_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe StaticPage::Base, type: :model do
+  subject { build(:static_page) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without slug" do
+    subject.slug = nil
+    expect(subject).to have(1).errors_on(:slug)
+  end
+
+  it "should not be valid when slug is not uniq" do
+    subject.save!
+    expect(build(:static_page, slug: subject.slug)).to have(1).errors_on(:slug)
+  end
+
+  it "should not be valid when image_credits_url is not url" do
+    subject.image_credits_url = "WRONG_URL"
+    expect(subject).to have(1).errors_on(:image_credits_url)
+  end
+
+  it "should not be valid without image" do
+    subject.image = nil
+    expect(subject).to have(1).errors_on(:image)
+  end
+
+  it "should not be valid when image is not image" do
+    subject.image.attach fixture_file_upload("document.pdf")
+    expect(subject).to have(1).errors_on(:image)
+  end
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+end

--- a/backend/spec/models/static_page/section_item_spec.rb
+++ b/backend/spec/models/static_page/section_item_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe StaticPage::SectionItem, type: :model do
+  subject { build(:static_page_section_item) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+
+  it "should not be valid when image is not image" do
+    subject.image.attach fixture_file_upload("document.pdf")
+    expect(subject).to have(1).errors_on(:image)
+  end
+end

--- a/backend/spec/models/static_page/section_paragraph_spec.rb
+++ b/backend/spec/models/static_page/section_paragraph_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe StaticPage::SectionParagraph, type: :model do
+  subject { build(:static_page_section_paragraph) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid when image_credits_url is not url" do
+    subject.image_credits_url = "WRONG_URL"
+    expect(subject).to have(1).errors_on(:image_credits_url)
+  end
+
+  it "should not be valid when image is not image" do
+    subject.image.attach fixture_file_upload("document.pdf")
+    expect(subject).to have(1).errors_on(:image)
+  end
+end

--- a/backend/spec/models/static_page/section_reference_spec.rb
+++ b/backend/spec/models/static_page/section_reference_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe StaticPage::SectionReference, type: :model do
+  subject { build(:static_page_section_reference) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+end

--- a/backend/spec/models/static_page/section_spec.rb
+++ b/backend/spec/models/static_page/section_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe StaticPage::Section, type: :model do
+  subject { build(:static_page_section) }
+
+  it { is_expected.to be_valid }
+
+  it "should not be valid without section_type" do
+    subject.section_type = nil
+    expect(subject).to have(1).errors_on(:section_type)
+  end
+
+  it "should not be valid without title" do
+    subject.title = nil
+    expect(subject.save).to be_falsey
+    expect(subject.errors["translations.title"]).to include("can't be blank")
+  end
+
+  it "should not be valid without position" do
+    subject.position = nil
+    expect(subject).to have(2).errors_on(:position)
+  end
+
+  it "should not be valid when position is negative" do
+    subject.position = -1
+    expect(subject).to have(1).errors_on(:position)
+  end
+end

--- a/backend/spec/systems/admin/static_pages_spec.rb
+++ b/backend/spec/systems/admin/static_pages_spec.rb
@@ -1,0 +1,256 @@
+require "system_helper"
+
+RSpec.describe "Admin: Static Pages", type: :system do
+  include ActionText::SystemTestHelper
+
+  let!(:admin_user) do
+    create :admin_user, email: "admin@example.com", password: "SuperSecret6", password_confirmation: "SuperSecret6"
+  end
+
+  before { login_as admin_user }
+
+  describe "#index" do
+    let!(:sources) { create_list :static_page, 3 }
+
+    before { visit admin_static_page_bases_path }
+
+    it "shows all resources" do
+      StaticPage::Base.all.each do |static_page|
+        expect(page).to have_text(static_page.id)
+        expect(page).to have_text(static_page.slug)
+        expect(page).to have_text(static_page.title)
+      end
+    end
+  end
+
+  describe "#show" do
+    let!(:static_page) { create :static_page }
+    let!(:static_page_section_paragraph) do
+      create :static_page_section_paragraph, section: create(:static_page_section, section_type: :paragraph, static_page: static_page)
+    end
+    let!(:static_page_section_item) do
+      create :static_page_section_item, section: create(:static_page_section, section_type: :items, static_page: static_page)
+    end
+    let!(:static_page_section_reference) do
+      create :static_page_section_reference, section: create(:static_page_section, section_type: :references, static_page: static_page)
+    end
+
+    before do
+      visit admin_static_page_bases_path
+      find("a[href='/admin/static_page_bases/#{static_page.id}']", text: "View").click
+    end
+
+    it "shows Static Page detail" do
+      expect(page).to have_text(static_page.id)
+      expect(page).to have_text(static_page.slug)
+      expect(page).to have_text(static_page.title)
+      expect(page).to have_text(static_page.image_credits)
+      expect(page).to have_text(static_page.image_credits_url)
+    end
+
+    it "shows Paragraph section detail" do
+      expect(page).to have_text(static_page_section_paragraph.section.id)
+      expect(page).to have_text(static_page_section_paragraph.section.title)
+      expect(page).to have_text(static_page_section_paragraph.section.title_size)
+      expect(page).to have_text(static_page_section_paragraph.section.slug)
+      expect(page).to have_text(ActionText::Content.new(static_page_section_paragraph.text).to_plain_text)
+      expect(page).to have_text(static_page_section_paragraph.image_position)
+      expect(page).to have_text(static_page_section_paragraph.image_credits)
+      expect(page).to have_text(static_page_section_paragraph.image_credits_url)
+    end
+
+    it "shows Item section detail" do
+      expect(page).to have_text(static_page_section_item.section.id)
+      expect(page).to have_text(static_page_section_item.section.title)
+      expect(page).to have_text(static_page_section_item.section.title_size)
+      expect(page).to have_text(static_page_section_item.section.slug)
+      expect(page).to have_text(static_page_section_item.title)
+      expect(page).to have_text(ActionText::Content.new(static_page_section_item.description).to_plain_text)
+    end
+
+    it "shows Reference section detail" do
+      expect(page).to have_text(static_page_section_reference.section.id)
+      expect(page).to have_text(static_page_section_reference.section.title)
+      expect(page).to have_text(static_page_section_reference.section.title_size)
+      expect(page).to have_text(static_page_section_reference.section.slug)
+      expect(page).to have_text(static_page_section_reference.slug)
+      expect(page).to have_text(ActionText::Content.new(static_page_section_reference.text).to_plain_text)
+    end
+  end
+
+  describe "#create" do
+    let(:new_static_page) { StaticPage::Base.last }
+
+    before do
+      visit admin_static_page_bases_path
+      click_on "New Static Page"
+    end
+
+    it "allows to create new static page" do
+      # base static page
+      fill_in "static_page_base[translations_attributes][0][title]", with: "New title"
+      fill_in "static_page_base[translations_attributes][0][image_credits]", with: "New image credits"
+      fill_in "static_page_base[slug]", with: "New slug"
+      attach_file "static_page_base[image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      fill_in "static_page_base[image_credits_url]", with: "https://image-credits.com"
+      # paragraph static page section
+      click_on "Add New Section"
+      fill_in "static_page_base[sections_attributes][0][translations_attributes][0][title]", with: "New Paragraph title"
+      fill_in "static_page_base[sections_attributes][0][slug]", with: "New Paragraph slug"
+      fill_in "static_page_base[sections_attributes][0][title_size]", with: "2"
+      select "paragraph", from: "static_page_base[sections_attributes][0][section_type]"
+      fill_in "static_page_base[sections_attributes][0][section_paragraph_attributes][translations_attributes][0][image_credits]", with: "New Paragraph image credits"
+      fill_in_rich_text_area "static_page_base[sections_attributes][0][section_paragraph_attributes][translations_attributes][0][text]", with: "New Paragraph text"
+      select "left", from: "static_page_base[sections_attributes][0][section_paragraph_attributes][image_position]"
+      fill_in "static_page_base[sections_attributes][0][section_paragraph_attributes][image_credits_url]", with: "https://paragraph-image-credits.com"
+      # items static page section
+      click_on "Add New Section"
+      fill_in "static_page_base[sections_attributes][1][translations_attributes][0][title]", with: "New Items title"
+      fill_in "static_page_base[sections_attributes][1][slug]", with: "New Items slug"
+      fill_in "static_page_base[sections_attributes][1][title_size]", with: "2"
+      select "items", from: "static_page_base[sections_attributes][1][section_type]"
+      click_on "Add New Section item"
+      fill_in "static_page_base[sections_attributes][1][section_items_attributes][0][translations_attributes][0][title]", with: "New Item title"
+      fill_in_rich_text_area "static_page_base[sections_attributes][1][section_items_attributes][0][translations_attributes][0][description]", with: "New Item description"
+      attach_file "static_page_base[sections_attributes][1][section_items_attributes][0][image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      # references static page section
+      click_on "Add New Section"
+      fill_in "static_page_base[sections_attributes][2][translations_attributes][0][title]", with: "New References title"
+      fill_in "static_page_base[sections_attributes][2][slug]", with: "New References slug"
+      fill_in "static_page_base[sections_attributes][2][title_size]", with: "2"
+      select "references", from: "static_page_base[sections_attributes][2][section_type]"
+      click_on "Add New Section reference"
+      fill_in "static_page_base[sections_attributes][2][section_references_attributes][0][slug]", with: "New Reference slug"
+      fill_in_rich_text_area "static_page_base[sections_attributes][2][section_references_attributes][0][translations_attributes][0][text]", with: "New Reference text"
+
+      click_on "Create Static Page"
+
+      expect(page).to have_current_path(admin_static_page_base_path(new_static_page))
+      expect(page).to have_text("Static Page was successfully created.")
+      # base static page
+      expect(page).to have_text("New slug")
+      expect(page).to have_text("New title")
+      expect(page).to have_text("New image credits")
+      expect(page).to have_text("https://image-credits.com")
+      # paragraph static page section
+      expect(page).to have_text("New Paragraph title")
+      expect(page).to have_text("New Paragraph slug")
+      expect(page).to have_text("left")
+      expect(page).to have_text("New Paragraph image credits")
+      expect(page).to have_text("New Paragraph text")
+      expect(page).to have_text("https://paragraph-image-credits.com")
+      # items static page section
+      expect(page).to have_text("New Items title")
+      expect(page).to have_text("New Items slug")
+      expect(page).to have_text("New Item title")
+      expect(page).to have_text("New Item description")
+      # references static page section
+      expect(page).to have_text("New References title")
+      expect(page).to have_text("New References slug")
+      expect(page).to have_text("New Reference slug")
+      expect(page).to have_text("New Reference text")
+    end
+
+    it "shows error when validation fails" do
+      fill_in "static_page_base[translations_attributes][0][title]", with: ""
+
+      click_on "Create Static Page"
+
+      expect(page).to have_current_path(admin_static_page_bases_path)
+      expect(page).to have_text("can't be blank")
+    end
+  end
+
+  describe "#update" do
+    let!(:static_page) { create :static_page }
+    let!(:static_page_section_paragraph) do
+      create :static_page_section_paragraph, section: create(:static_page_section, section_type: :paragraph, position: 1, static_page: static_page)
+    end
+    let!(:static_page_section_item) do
+      create :static_page_section_item, section: create(:static_page_section, section_type: :items, position: 2, static_page: static_page)
+    end
+    let!(:static_page_section_reference) do
+      create :static_page_section_reference, section: create(:static_page_section, section_type: :references, position: 3, static_page: static_page)
+    end
+
+    before do
+      visit admin_static_page_bases_path
+      find("a[href='/admin/static_page_bases/#{static_page.id}/edit']").click
+    end
+
+    it "allows to update existing static page" do
+      # base static page
+      all("fieldset.has-many-toggle-collapse").each { |element| element.click }
+      fill_in "static_page_base[translations_attributes][0][title]", with: "Updated title"
+      fill_in "static_page_base[translations_attributes][0][image_credits]", with: "Updated image credits"
+      fill_in "static_page_base[slug]", with: "Updated slug"
+      attach_file "static_page_base[image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      fill_in "static_page_base[image_credits_url]", with: "https://updated-image-credits.com"
+      # paragraph static page section
+      fill_in "static_page_base[sections_attributes][0][translations_attributes][0][title]", with: "Updated Paragraph title"
+      fill_in "static_page_base[sections_attributes][0][slug]", with: "Updated Paragraph slug"
+      fill_in "static_page_base[sections_attributes][0][section_paragraph_attributes][translations_attributes][0][image_credits]", with: "Updated Paragraph image credits"
+      fill_in_rich_text_area "static_page_base[sections_attributes][0][section_paragraph_attributes][translations_attributes][0][text]", with: "Updated Paragraph text"
+      select "left", from: "static_page_base[sections_attributes][0][section_paragraph_attributes][image_position]"
+      fill_in "static_page_base[sections_attributes][0][section_paragraph_attributes][image_credits_url]", with: "https://updated-paragraph-image-credits.com"
+      # items static page section
+      all("fieldset.has-many-toggle-collapse").each { |element| element.click }
+      fill_in "static_page_base[sections_attributes][1][translations_attributes][0][title]", with: "Updated Items title"
+      fill_in "static_page_base[sections_attributes][1][slug]", with: "Updated Items slug"
+      fill_in "static_page_base[sections_attributes][1][section_items_attributes][0][translations_attributes][0][title]", with: "Updated Item title"
+      fill_in_rich_text_area "static_page_base[sections_attributes][1][section_items_attributes][0][translations_attributes][0][description]", with: "Updated Item description"
+      attach_file "static_page_base[sections_attributes][1][section_items_attributes][0][image]", Rails.root.join("spec/fixtures/files/picture.jpg")
+      # references static page section
+      all("fieldset.has-many-toggle-collapse").each { |element| element.click }
+      fill_in "static_page_base[sections_attributes][2][translations_attributes][0][title]", with: "Updated References title"
+      fill_in "static_page_base[sections_attributes][2][slug]", with: "Updated References slug"
+      fill_in "static_page_base[sections_attributes][2][section_references_attributes][0][slug]", with: "Updated Reference slug"
+      fill_in_rich_text_area "static_page_base[sections_attributes][2][section_references_attributes][0][translations_attributes][0][text]", with: "Updated Reference text"
+
+      click_on "Update Static Page"
+
+      expect(page).to have_current_path(admin_static_page_base_path(static_page))
+      expect(page).to have_text("Static Page was successfully updated.")
+      # base static page
+      expect(page).to have_text("Updated slug")
+      expect(page).to have_text("Updated title")
+      expect(page).to have_text("Updated image credits")
+      expect(page).to have_text("https://updated-image-credits.com")
+      # paragraph static page section
+      expect(page).to have_text("Updated Paragraph title")
+      expect(page).to have_text("Updated Paragraph slug")
+      expect(page).to have_text("left")
+      expect(page).to have_text("Updated Paragraph image credits")
+      expect(page).to have_text("Updated Paragraph text")
+      expect(page).to have_text("https://updated-paragraph-image-credits.com")
+      # items static page section
+      expect(page).to have_text("Updated Items title")
+      expect(page).to have_text("Updated Items slug")
+      expect(page).to have_text("Updated Item title")
+      expect(page).to have_text("Updated Item description")
+      # references static page section
+      expect(page).to have_text("Updated References title")
+      expect(page).to have_text("Updated References slug")
+      expect(page).to have_text("Updated Reference slug")
+      expect(page).to have_text("Updated Reference text")
+    end
+  end
+
+  describe "#delete" do
+    let!(:static_page) { create :static_page }
+
+    before do
+      visit admin_static_page_bases_path
+    end
+
+    it "deletes existing static_page" do
+      expect(page).to have_text(static_page.slug)
+
+      accept_confirm do
+        find("a[data-method='delete'][href='/admin/static_page_bases/#{static_page.id}']").click
+      end
+
+      expect(page).not_to have_text(static_page.slug)
+    end
+  end
+end


### PR DESCRIPTION
I am slightly ahead of schedule with this feature. Based on investigation done within task https://vizzuality.atlassian.net/browse/RA2-168, this PR adds models and Administration which allows to create About page (Static pages).

Description of newly added models can be found at https://dbdiagram.io/d/64366ba28615191cfa8d4441 diagram. Basically there are 5 new tables:
 - one which is used as base for new static page
 - every static page can be composed of multiple sections
 - every section can be of different type --> paragraph, items or references. We use different tables to store different data for different section types.

Administration is using similar approach which was used for Journeys or Homepages. All entities can be created via one complex form --> individual sections are for example defined through `has_many` active admin method, etc. Individual sections are collapsible and based on selected section type, different part of form is visible. It is definitely easier for user to edit everything via one formular, but it is starting to feel quite complex already and we are really stretching what ActiveAdmin can do --> for even more complex structure (which hopefully will not come :D), It will be required to break it into multiple forms.

## Testing instructions

Login as admin and open Static Pages section. Try to create new static page which covers all important sections mentioned at https://www.resilienceatlas.org/about --> one paragraph, one person of Team, one Sponsor and for example one Reference. Verify that data can be saved and they are visible and editable at backoffice.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-168
