### PR TITLE
Dynamic content translations

### DIFF
--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -18,7 +18,7 @@ const disableRequestCache = (req) => {
 Cypress.Commands.add('interceptAllRequests', () => {
   cy.log('Intercepting requests');
 
-  cy.intercept({ method: 'GET', url: '/api/site', middleware: true }, disableRequestCache).as(
+  cy.intercept({ method: 'GET', url: '/api/site*', middleware: true }, disableRequestCache).as(
     'siteRequest',
   );
 

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -45,7 +45,7 @@ Cypress.Commands.add('interceptAllRequests', () => {
   }).as('journeyDetailRequest');
 
   cy.intercept(
-    { method: 'GET', url: '/api/layer-groups', middleware: true },
+    { method: 'GET', url: '/api/layer-groups*', middleware: true },
     disableRequestCache,
   ).as('layerGroupsAPIRequest');
 

--- a/frontend/server-side-translations/server-side-translation-content.json
+++ b/frontend/server-side-translations/server-side-translation-content.json
@@ -14,5 +14,8 @@
   "Report",
   "Shinny App",
   "Journeys",
-  "Journey Step"
+  "Journey Step",
+  "layers",
+  "models",
+  "Select a model"
 ]

--- a/frontend/src/state/modules/layer_groups/actions.js
+++ b/frontend/src/state/modules/layer_groups/actions.js
@@ -1,6 +1,7 @@
 import { subdomain } from 'utilities/getSubdomain';
 import api, { createApiAction } from '../../utils/api';
 import { layer_group } from '../../schema';
+import { toBackendLocale } from 'utilities/helpers';
 
 const URL_LAYER_GROUPS = '/layer-groups';
 
@@ -20,7 +21,15 @@ export const openBatch = (ids = []) => ({
   ids,
 });
 
-export const load = () =>
-  api(LOAD, ({ get }) => get(URL_LAYER_GROUPS, { params: { site_scope: subdomain } }), {
-    schema: [layer_group],
-  });
+export const load = (locale) =>
+  api(
+    LOAD,
+    ({ get }) =>
+      get(URL_LAYER_GROUPS, {
+        params: { site_scope: subdomain, locale: toBackendLocale(locale) },
+      }),
+    {
+      schema: [layer_group],
+      locale,
+    },
+  );

--- a/frontend/src/state/modules/layer_groups/reducer.js
+++ b/frontend/src/state/modules/layer_groups/reducer.js
@@ -10,6 +10,7 @@ const initialState = {
   ],
   loading: false,
   loaded: false,
+  loadedLocale: null,
   error: null,
 };
 
@@ -19,14 +20,16 @@ export default createReducer(initialState)({
     loading: true,
     error: null,
   }),
-  [LOAD.SUCCESS]: (state, { payload }) => ({
-    ...state,
-    byId: payload.entities.layer_groups,
-    all: payload.result,
-    loaded: true,
-    loading: false,
-  }),
-
+  [LOAD.SUCCESS]: (state, { payload, meta: { locale } }) => {
+    return {
+      ...state,
+      byId: payload.entities.layer_groups,
+      all: payload.result,
+      loaded: true,
+      loadedLocale: locale,
+      loading: false,
+    };
+  },
   [LOAD.FAIL]: (state) => ({
     ...state,
     loading: false,

--- a/frontend/src/state/modules/layers/actions.js
+++ b/frontend/src/state/modules/layers/actions.js
@@ -1,10 +1,11 @@
 import { subdomain } from 'utilities/getSubdomain';
 import api, { createApiAction } from '../../utils/api';
 import { layer, source } from '../../schema';
+import { toBackendLocale } from 'utilities/helpers';
 
 // TODO: migrate
 // const URL_LAYERS = `/layers?lang=${window.currentLocation || 'en'}`;
-const URL_LAYERS = `/layers?lang=en`;
+const URL_LAYERS = `/layers`;
 
 // Action constants
 export const LOAD = createApiAction('layers/LOAD');
@@ -14,11 +15,17 @@ export const SET_OPACITY = 'layers / SET_OPACITY';
 export const SET_CHART_LIMIT = 'layers / SET_CHART_LIMIT';
 export const REORDER = 'layers / REORDER';
 
-export const load = () =>
-  api(LOAD, ({ get }) => get(URL_LAYERS, { params: { site_scope: subdomain } }), {
-    schema: [layer],
-    includedSchema: [source],
-  });
+export const load = (locale) =>
+  api(
+    LOAD,
+    ({ get }) =>
+      get(URL_LAYERS, { params: { site_scope: subdomain, locale: toBackendLocale(locale) } }),
+    {
+      schema: [layer],
+      includedSchema: [source],
+      locale,
+    },
+  );
 
 export const setActives = (actives) => ({
   type: SET_ACTIVES,

--- a/frontend/src/state/modules/layers/reducer.js
+++ b/frontend/src/state/modules/layers/reducer.js
@@ -16,6 +16,7 @@ const initialState = {
   actives: [...persistedLayers.result],
   loading: false,
   loaded: false,
+  loadedLocale: null,
   error: null,
 };
 
@@ -26,7 +27,7 @@ export default createReducer(initialState)({
     error: null,
   }),
 
-  [LOAD.SUCCESS]: (state, { payload }) => {
+  [LOAD.SUCCESS]: (state, { payload, meta: { locale } }) => {
     const {
       entities: { layers },
       result,
@@ -44,11 +45,12 @@ export default createReducer(initialState)({
 
     return {
       ...state,
-      byId: merge(layers, state.byId),
+      byId: merge(state.byId, layers),
       all: payload.result,
       actives: [...actives],
       loading: false,
       loaded: true,
+      loadedLocale: locale,
     };
   },
 

--- a/frontend/src/state/modules/map_menu_entries/actions.js
+++ b/frontend/src/state/modules/map_menu_entries/actions.js
@@ -1,9 +1,13 @@
 import api, { createApiAction } from '../../utils/api';
 import { map_menu_entry } from '../../schema';
+import { toBackendLocale } from 'utilities';
 
 const URL_ENTRIES = '/menu-entries';
 
 // Action constants
 export const LOAD = createApiAction('map_menu_entries/LOAD');
 
-export const load = () => api(LOAD, ({ get }) => get(URL_ENTRIES), { schema: [map_menu_entry] });
+export const load = (locale) =>
+  api(LOAD, ({ get }) => get(URL_ENTRIES, { params: { locale: toBackendLocale(locale) } }), {
+    schema: [map_menu_entry],
+  });

--- a/frontend/src/state/modules/map_menu_entries/reducer.js
+++ b/frontend/src/state/modules/map_menu_entries/reducer.js
@@ -10,6 +10,7 @@ const initialState = {
   ],
   loading: false,
   loaded: false,
+  loadedLocale: null,
   error: null,
 };
 

--- a/frontend/src/state/modules/predictive_models/actions.js
+++ b/frontend/src/state/modules/predictive_models/actions.js
@@ -1,3 +1,4 @@
+import { toBackendLocale } from 'utilities/helpers';
 import api, { createApiAction } from '../../utils/api';
 import { model } from '../../schema';
 
@@ -37,13 +38,13 @@ export const resetIndicators = () => ({
   type: RESET_INDICATORS,
 });
 
-export const load = () =>
+export const load = (locale) =>
   api(
     LOAD,
     ({ get }, d, getState) => {
       const site_scope = getState().site.id;
 
-      return get(URL_MODELS, { params: { site_scope } });
+      return get(URL_MODELS, { params: { site_scope, locale: toBackendLocale(locale) } });
     },
     {
       schema: [model],

--- a/frontend/src/state/modules/predictive_models/reducer.js
+++ b/frontend/src/state/modules/predictive_models/reducer.js
@@ -28,12 +28,15 @@ const initialState = {
   indicators: {
     /* [indicatorId]: { indicator } */
   },
-  indicators_state: persistedIndicators.map(Number),
+  indicators_state: Array.isArray(persistedIndicators)
+    ? persistedIndicators?.map(Number)
+    : persistedIndicators?.split(',').map(Number),
   categories: {
     /* [categoryId]: { category } */
   },
   loading: false,
   loaded: false,
+  loadedLocale: null,
   error: null,
 };
 
@@ -44,7 +47,7 @@ export default createReducer(initialState)({
     error: null,
   }),
 
-  [LOAD.SUCCESS]: (state, { payload, included }) => {
+  [LOAD.SUCCESS]: (state, { payload, included, meta: { locale } }) => {
     const { models = {} } = payload.entities;
     const { categories, indicators } = included.entities;
     const newState = {
@@ -55,6 +58,7 @@ export default createReducer(initialState)({
       indicators,
       loading: false,
       loaded: true,
+      loadedLocale: locale,
     };
 
     const newIndicators = buildIndicatorsFromState(newState);

--- a/frontend/src/state/modules/site/actions.js
+++ b/frontend/src/state/modules/site/actions.js
@@ -1,5 +1,6 @@
 import { subdomain } from 'utilities/getSubdomain';
 import api, { createApiAction } from '../../utils/api';
+import { toBackendLocale } from 'utilities/helpers';
 import { site_scope } from '../../schema';
 
 const URL_SITE = '/site';
@@ -7,7 +8,12 @@ const URL_SITE = '/site';
 // Action constants
 export const LOAD = createApiAction('site/LOAD');
 
-export const load = () =>
-  api(LOAD, ({ get }) => get(URL_SITE, { params: { site_scope: subdomain } }), {
-    schema: site_scope,
-  });
+export const load = (locale) =>
+  api(
+    LOAD,
+    ({ get }) =>
+      get(URL_SITE, { params: { site_scope: subdomain, locale: toBackendLocale(locale) } }),
+    {
+      schema: site_scope,
+    },
+  );

--- a/frontend/src/state/modules/site/reducer.js
+++ b/frontend/src/state/modules/site/reducer.js
@@ -28,7 +28,7 @@ export default createReducer(initialState)({
     loading: true,
   }),
 
-  [LOAD.SUCCESS]: (state, { payload }) => {
+  [LOAD.SUCCESS]: (state, { payload, meta: { locale } }) => {
     const data = payload.entities.site_scopes[payload.result];
 
     return {
@@ -38,6 +38,7 @@ export default createReducer(initialState)({
 
       loading: false,
       loaded: true,
+      loadedLocale: locale,
     };
   },
 

--- a/frontend/src/state/modules/sources/actions.js
+++ b/frontend/src/state/modules/sources/actions.js
@@ -1,1 +1,0 @@
-import api, { createApiAction } from '../../utils/api';

--- a/frontend/src/state/modules/sources/index.js
+++ b/frontend/src/state/modules/sources/index.js
@@ -1,4 +1,3 @@
-// export * from './actions';
 export * from './selectors';
 
 export { default } from './reducer';

--- a/frontend/src/utilities/helpers.js
+++ b/frontend/src/utilities/helpers.js
@@ -146,4 +146,4 @@ export function hexToRGB(hex, alpha) {
   }
 }
 
-export const toBackendLocale = (locale) => locale.replace('_', '-');
+export const toBackendLocale = (locale) => locale && locale.replace('_', '-');

--- a/frontend/src/utilities/helpers.js
+++ b/frontend/src/utilities/helpers.js
@@ -145,3 +145,5 @@ export function hexToRGB(hex, alpha) {
     return 'rgb(' + r + ', ' + g + ', ' + b + ')';
   }
 }
+
+export const toBackendLocale = (locale) => locale.replace('_', '-');

--- a/frontend/src/views/components/Legend/Legend.container.js
+++ b/frontend/src/views/components/Legend/Legend.container.js
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'next/router';

--- a/frontend/src/views/components/Map/Map.component.jsx
+++ b/frontend/src/views/components/Map/Map.component.jsx
@@ -54,8 +54,8 @@ const MapView = (props) => {
   const layerManagerRef = useContext(LayerManagerContext);
 
   useEffect(() => {
-    if (!layersLoaded || layersLoadedLocale !== locale) loadLayers();
-    if (!layerGroupsLoaded || layerGroupsLoadedLocale !== locale) loadLayerGroups();
+    if (!layersLoaded || layersLoadedLocale !== locale) loadLayers(locale);
+    if (!layerGroupsLoaded || layerGroupsLoadedLocale !== locale) loadLayerGroups(locale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locale]);
 

--- a/frontend/src/views/components/Map/Map.component.jsx
+++ b/frontend/src/views/components/Map/Map.component.jsx
@@ -34,8 +34,8 @@ const MapView = (props) => {
     setMapLayerGroupsInteraction,
     setMapLayerGroupsInteractionLatLng,
     // data
-    layers: { loaded: layersLoaded },
-    layer_groups: { loaded: layerGroupsLoaded },
+    layers: { loaded: layersLoaded, loadedLocale: layersLoadedLocale },
+    layer_groups: { loaded: layerGroupsLoaded, loadedLocale: layerGroupsLoadedLocale },
     activeLayers,
     model_layer,
     defaultActiveGroups,
@@ -48,16 +48,16 @@ const MapView = (props) => {
     embed,
     drawing,
   } = props;
-  const { query } = router;
+  const { query, locale } = router;
   const { setParam } = useRouterParams();
 
   const layerManagerRef = useContext(LayerManagerContext);
 
   useEffect(() => {
-    if (!layersLoaded) loadLayers();
-    if (!layerGroupsLoaded) loadLayerGroups();
+    if (!layersLoaded || layersLoadedLocale !== locale) loadLayers();
+    if (!layerGroupsLoaded || layerGroupsLoadedLocale !== locale) loadLayerGroups();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     if (layersLoaded && layerGroupsLoaded && defaultActiveGroups.length) {

--- a/frontend/src/views/components/PredictiveModels/PredictiveModels.component.jsx
+++ b/frontend/src/views/components/PredictiveModels/PredictiveModels.component.jsx
@@ -3,7 +3,7 @@ import qs from 'qs';
 import Loader from 'views/shared/Loader';
 import { T } from '@transifex/react';
 import { useRouterParams } from 'utilities';
-
+import { useRouter } from 'next/router';
 import Indicator from './Indicator';
 
 const PredictiveModels = ({
@@ -18,15 +18,17 @@ const PredictiveModels = ({
   indicatorsState,
   modelsLoading,
   modelsLoaded,
+  modelsLoadedLocale,
   selectedModel,
   translations,
 }) => {
+  const { locale } = useRouter();
   const { setParam } = useRouterParams();
 
   useEffect(() => {
-    if (!modelsLoaded) loadModels();
+    if (!modelsLoaded || modelsLoadedLocale !== locale) loadModels(locale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     // detect only changes caused by user
@@ -71,7 +73,7 @@ const PredictiveModels = ({
           onChange={(e) => select(e.currentTarget.value)}
         >
           <option disabled value="default">
-            <T _str="Select a model" />
+            {(translations && translations['Select a model']) || 'Select a model'}
           </option>
           {models.map(({ id, name }) => (
             <option key={id} value={id}>

--- a/frontend/src/views/components/PredictiveModels/PredictiveModels.container.js
+++ b/frontend/src/views/components/PredictiveModels/PredictiveModels.container.js
@@ -21,6 +21,7 @@ const makeMapStateToProps = () => {
     selectedModel: state.predictive_models.selected,
     modelsLoading: state.predictive_models.loading,
     modelsLoaded: state.predictive_models.loaded,
+    modelsLoadedLocale: state.predictive_models.loadedLocale,
     translations: state.translations.data,
   });
 

--- a/frontend/src/views/components/Sidebar/Sidebar.component.jsx
+++ b/frontend/src/views/components/Sidebar/Sidebar.component.jsx
@@ -13,9 +13,10 @@ import Tabs from 'views/shared/Tabs';
 
 import { useRouterParams } from 'utilities';
 
+// SSR translated strings
 export const TABS = {
-  LAYERS: <T _str="layers" />,
-  MODELS: <T _str="models" />,
+  LAYERS: 'layers',
+  MODELS: 'models',
 };
 
 const Sidebar = ({
@@ -69,7 +70,7 @@ const Sidebar = ({
             menuClassName="tabs tabs-secondary-content"
             renderTabTitle={({ name, title, active, onTabSwitch }) => (
               <li className={cx('tab-title', { active })}>
-                <LinkButton data-section={name} onClick={onTabSwitch}>
+                <LinkButton data-section={translations && translations[name]} onClick={onTabSwitch}>
                   {title}
                 </LinkButton>
               </li>

--- a/frontend/src/views/components/Sidebar/Sidebar.container.js
+++ b/frontend/src/views/components/Sidebar/Sidebar.container.js
@@ -12,6 +12,7 @@ const mapStateToProps = (state) => ({
   models: state.predictive_models.all,
   modelsLoaded: state.predictive_models.loaded,
   site: state.site,
+  translations: state.translations.data,
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/views/layouts/_header/component.jsx
+++ b/frontend/src/views/layouts/_header/component.jsx
@@ -49,7 +49,9 @@ const Header = ({
             </Link>
           </li>
         </ul>
-
+        <ul className="nav-area">
+          <LanguageSwitcher translations={translations} />
+        </ul>
         <ul className="nav-area -resilience">
           <li className="journey-link">
             <Link href="/journeys">
@@ -112,10 +114,7 @@ const Header = ({
               </li>
             </>
           )}
-
-          <LanguageSwitcher translations={translations} />
         </ul>
-
         <ul className="nav-area -vital-sign">
           <li>
             <a

--- a/frontend/src/views/layouts/_header/component.jsx
+++ b/frontend/src/views/layouts/_header/component.jsx
@@ -15,13 +15,14 @@ const Header = ({
   site: { linkback_text, linkback_url },
   menuItems,
   menuItemsLoaded,
+  menuItemsLoadedLocale,
   translations,
 }) => {
-  const { pathname } = useRouter();
+  const { pathname, locale } = useRouter();
 
   useEffect(() => {
-    if (!menuItemsLoaded) loadMenuItems();
-  }, [loadMenuItems, menuItemsLoaded]);
+    if (!menuItemsLoaded || menuItemsLoadedLocale !== locale) loadMenuItems(locale);
+  }, [loadMenuItems, menuItemsLoaded, menuItemsLoadedLocale, locale]);
 
   const renderMenuItem = useCallback(
     ({ id, label, link, children }) => (

--- a/frontend/src/views/layouts/_header/index.js
+++ b/frontend/src/views/layouts/_header/index.js
@@ -11,6 +11,7 @@ const makeMapStateToProps = () => {
     site: state.site,
     menuItems: getMenuItems(state),
     menuItemsLoaded: state.map_menu_entries.loaded,
+    menuItemsLoaded: state.map_menu_entries.loadedLocale,
     translations: state.translations.data,
   });
 

--- a/frontend/src/views/layouts/_header/index.js
+++ b/frontend/src/views/layouts/_header/index.js
@@ -11,7 +11,7 @@ const makeMapStateToProps = () => {
     site: state.site,
     menuItems: getMenuItems(state),
     menuItemsLoaded: state.map_menu_entries.loaded,
-    menuItemsLoaded: state.map_menu_entries.loadedLocale,
+    menuItemsLoadedLocale: state.map_menu_entries.loadedLocale,
     translations: state.translations.data,
   });
 

--- a/frontend/src/views/layouts/embed.tsx
+++ b/frontend/src/views/layouts/embed.tsx
@@ -25,14 +25,15 @@ const bare = false;
 const EmbedPage: React.FC<EmbedPageProps> = (props) => {
   const { site, page, pageTitle, children, dispatch } = props;
   const { subdomain, header_theme } = site;
+  const router = useRouter();
+  const { locale, query } = router;
 
   // Currently data fetching in Layouts are not supporting getServerSideProps
   // https://nextjs.org/docs/basic-features/layouts#data-fetching
   // NOTE: consider move this to every page that needs it using getServerSideProps
-  useEffect(() => dispatch(loadSite()), [dispatch]);
+  useEffect(() => dispatch(loadSite(locale)), [dispatch, locale]);
 
-  const router = useRouter();
-  const isJourneyMap = router?.query?.journeyMap;
+  const isJourneyMap = query?.journeyMap;
 
   return (
     <div

--- a/frontend/src/views/layouts/fullscreen.tsx
+++ b/frontend/src/views/layouts/fullscreen.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import PrivacyBanner from 'views/components/PrivacyBanner';
 import type { TypedT } from 'types/transifex';
 import { load as loadSite } from 'state/modules/site';
+import { useRouter } from 'next/router';
 
 import Head from './_head';
 import Header from './_header';
@@ -30,11 +31,12 @@ const FullscreenLayout: React.FC<FullscreenLayoutProps> = ({
   dispatch,
 }) => {
   const { subdomain, header_theme } = site;
-
+  const router = useRouter();
+  const { locale } = router;
   // Currently data fetching in Layouts are not supporting getServerSideProps
   // https://nextjs.org/docs/basic-features/layouts#data-fetching
   // NOTE: consider move this to every page that needs it using getServerSideProps
-  useEffect(() => dispatch(loadSite()), [dispatch]);
+  useEffect(() => dispatch(loadSite(locale)), [dispatch, locale]);
 
   return (
     <div

--- a/frontend/src/views/layouts/main.tsx
+++ b/frontend/src/views/layouts/main.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import PrivacyBanner from 'views/components/PrivacyBanner';
 
 import { load as loadSite } from 'state/modules/site';
+import { useRouter } from 'next/router';
 
 import Head from './_head';
 import Header from './_header';
@@ -26,10 +27,12 @@ const bare = false;
 const MainLayout: React.FC<MainLayoutProps> = (props) => {
   const { site, page, pageTitle, children, dispatch } = props;
   const { subdomain, header_theme } = site;
+  const router = useRouter();
+  const { locale } = router;
   // Currently data fetching in Layouts are not supporting getServerSideProps
   // https://nextjs.org/docs/basic-features/layouts#data-fetching
   // NOTE: consider move this to every page that needs it using getServerSideProps
-  useEffect(() => dispatch(loadSite()), [dispatch]);
+  useEffect(() => dispatch(loadSite(locale)), [dispatch, locale]);
   return (
     <div
       className={cx(

--- a/frontend/src/views/layouts/report.tsx
+++ b/frontend/src/views/layouts/report.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import cx from 'classnames';
 import { connect } from 'react-redux';
 import PrivacyBanner from 'views/components/PrivacyBanner';
+import { useRouter } from 'next/router';
 
 import { load as loadSite } from 'state/modules/site';
 
@@ -23,11 +24,12 @@ const page = 'report';
 
 const ReportLayout: React.FC<ReportLayoutProps> = ({ site, pageTitle, children, dispatch }) => {
   const { subdomain, header_theme } = site;
-
+  const router = useRouter();
+  const { locale } = router;
   // Currently data fetching in Layouts are not supporting getServerSideProps
   // https://nextjs.org/docs/basic-features/layouts#data-fetching
   // NOTE: consider move this to every page that needs it using getServerSideProps
-  useEffect(() => dispatch(loadSite()), [dispatch]);
+  useEffect(() => dispatch(loadSite(locale)), [dispatch, locale]);
 
   return (
     <div

--- a/frontend/src/views/styles/modules/_m-sidebar.scss
+++ b/frontend/src/views/styles/modules/_m-sidebar.scss
@@ -13,6 +13,11 @@
   }
 
   .tab-title {
+    max-width: 200px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
     a {
       padding: 10px 20px;
       background-color: transparent;


### PR DESCRIPTION
Dynamic translations

---
This PR translates some parts of the frontend that come from the back-office:

- [x] Layers on the sidebar:
Layers: https://staging.resilienceatlas.org/admin/layers
Layer groups: https://staging.resilienceatlas.org/admin/layer_groups
- [x] Sources: https://staging.resilienceatlas.org/admin/sources
- [x] Map menu entries: https://staging.resilienceatlas.org/admin/map_menu_entries
- [x] Predictive models - Check: https://localhost:3000/map?site_scope=ndp
  Categories: https://staging.resilienceatlas.org/admin/categories
  Indicators: https://staging.resilienceatlas.org/admin/indicators
  Models: https://staging.resilienceatlas.org/admin/models - ?
- [X] Site scopes: https://staging.resilienceatlas.org/admin/site_scopes

- <del>Site pages</del>: https://staging.resilienceatlas.org/admin/site_pages - This is not implemented on the frontend

## Testing instructions

Check that all this content from the map pages and menus is translated correctly. Remember that for now only the translated items will display.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-98?atlOrigin=eyJpIjoiZDcyYmE2Y2MwNjg3NDk1MDhmMDMxMTE1NjMwMzkzOGYiLCJwIjoiaiJ9
