### PR TITLE
feat: API endpoint for getting static pages

### DIFF
--- a/backend/app/controllers/api/v1/static_pages_controller.rb
+++ b/backend/app/controllers/api/v1/static_pages_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class StaticPagesController < ApiController
+      def show
+        static_page = StaticPage::Base.find_by! slug: params[:id]
+        render json: static_page,
+          serializer: StaticPageSerializer,
+          include: %w[sections sections.section_items sections.section_paragraph sections.section_references]
+      end
+    end
+  end
+end

--- a/backend/app/models/static_page/base.rb
+++ b/backend/app/models/static_page/base.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_bases
+#
+#  id                :bigint           not null, primary key
+#  slug              :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  image_credits     :string
+#
 module StaticPage
   class Base < ApplicationRecord
     has_many :sections, class_name: "StaticPage::Section", foreign_key: "static_page_id", inverse_of: :static_page, dependent: :destroy

--- a/backend/app/models/static_page/section.rb
+++ b/backend/app/models/static_page/section.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: static_page_sections
+#
+#  id                 :bigint           not null, primary key
+#  static_page_id     :bigint           not null
+#  position           :integer          not null
+#  slug               :string
+#  section_type       :string           not null
+#  title_size         :integer          default(2)
+#  show_at_navigation :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  title              :string
+#
 module StaticPage
   class Section < ApplicationRecord
     belongs_to :static_page, class_name: "StaticPage::Base", inverse_of: :sections

--- a/backend/app/models/static_page/section_item.rb
+++ b/backend/app/models/static_page/section_item.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_section_items
+#
+#  id          :bigint           not null, primary key
+#  section_id  :bigint           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  title       :string
+#  description :text
+#
 module StaticPage
   class SectionItem < ApplicationRecord
     belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_items

--- a/backend/app/models/static_page/section_paragraph.rb
+++ b/backend/app/models/static_page/section_paragraph.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: static_page_section_paragraphs
+#
+#  id                :bigint           not null, primary key
+#  section_id        :bigint           not null
+#  image_position    :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  text              :text
+#  image_credits     :string
+#
 module StaticPage
   class SectionParagraph < ApplicationRecord
     belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_paragraph

--- a/backend/app/models/static_page/section_reference.rb
+++ b/backend/app/models/static_page/section_reference.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_section_references
+#
+#  id         :bigint           not null, primary key
+#  section_id :bigint           not null
+#  slug       :string
+#  position   :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  text       :text
+#
 module StaticPage
   class SectionReference < ApplicationRecord
     belongs_to :section, class_name: "StaticPage::Section", inverse_of: :section_references

--- a/backend/app/serializers/static_page/section_item_serializer.rb
+++ b/backend/app/serializers/static_page/section_item_serializer.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: static_page_section_items
+#
+#  id          :bigint           not null, primary key
+#  section_id  :bigint           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  title       :string
+#  description :text
+#
+class StaticPage::SectionItemSerializer < ActiveModel::Serializer
+  include BlobSerializer
+
+  attributes :title, :description, :image, :position
+
+  def image
+    image_links_for object.image
+  end
+end

--- a/backend/app/serializers/static_page/section_paragraph_serializer.rb
+++ b/backend/app/serializers/static_page/section_paragraph_serializer.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: static_page_section_paragraphs
+#
+#  id                :bigint           not null, primary key
+#  section_id        :bigint           not null
+#  image_position    :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  text              :text
+#  image_credits     :string
+#
+class StaticPage::SectionParagraphSerializer < ActiveModel::Serializer
+  include BlobSerializer
+
+  attributes :text, :image, :image_credits, :image_credits_url, :image_position
+
+  def image
+    image_links_for object.image
+  end
+end

--- a/backend/app/serializers/static_page/section_reference_serializer.rb
+++ b/backend/app/serializers/static_page/section_reference_serializer.rb
@@ -10,14 +10,6 @@
 #  updated_at :datetime         not null
 #  text       :text
 #
-FactoryBot.define do
-  factory :static_page_section_reference, class: "StaticPage::SectionReference" do
-    section factory: :static_page_section
-    sequence(:slug) { |n| "StaticPageReference-#{n}" }
-    sequence(:text) do |n|
-      Faker::Config.random = Random.new(n)
-      Faker::Lorem.paragraph
-    end
-    position { 1 }
-  end
+class StaticPage::SectionReferenceSerializer < ActiveModel::Serializer
+  attributes :slug, :text, :position
 end

--- a/backend/app/serializers/static_page/section_serializer.rb
+++ b/backend/app/serializers/static_page/section_serializer.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: static_page_sections
+#
+#  id                 :bigint           not null, primary key
+#  static_page_id     :bigint           not null
+#  position           :integer          not null
+#  slug               :string
+#  section_type       :string           not null
+#  title_size         :integer          default(2)
+#  show_at_navigation :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  title              :string
+#
+class StaticPage::SectionSerializer < ActiveModel::Serializer
+  attributes :title, :slug, :title_size, :section_type, :show_at_navigation, :position
+
+  has_one :section_paragraph, serializer: StaticPage::SectionParagraphSerializer
+  has_many :section_items, serializer: StaticPage::SectionItemSerializer do |serializer|
+    serializer.object.section_items.order :position
+  end
+  has_many :section_references, serializer: StaticPage::SectionReferenceSerializer do |serializer|
+    serializer.object.section_references.order :position
+  end
+end

--- a/backend/app/serializers/static_page_serializer.rb
+++ b/backend/app/serializers/static_page_serializer.rb
@@ -1,0 +1,13 @@
+class StaticPageSerializer < ActiveModel::Serializer
+  include BlobSerializer
+
+  cache key: "static_page_#{I18n.locale}"
+  attributes :title, :slug, :image, :image_credits, :image_credits_url
+  has_many :sections, serializer: StaticPage::SectionSerializer do |serializer|
+    serializer.object.sections.order :position
+  end
+
+  def image
+    image_links_for object.image
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       get "/homepage", to: "homepages#show"
       resources :photos, only: :create
       resources :feedbacks, only: :create
+      resources :static_pages, only: :show
     end
   end
 

--- a/backend/spec/factories/static_page/bases.rb
+++ b/backend/spec/factories/static_page/bases.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_bases
+#
+#  id                :bigint           not null, primary key
+#  slug              :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  image_credits     :string
+#
 FactoryBot.define do
   factory :static_page, class: "StaticPage::Base" do
     sequence(:slug) { |n| "StaticPage-#{n}" }

--- a/backend/spec/factories/static_page/section_items.rb
+++ b/backend/spec/factories/static_page/section_items.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_section_items
+#
+#  id          :bigint           not null, primary key
+#  section_id  :bigint           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  title       :string
+#  description :text
+#
 FactoryBot.define do
   factory :static_page_section_item, class: "StaticPage::SectionItem" do
     section factory: :static_page_section

--- a/backend/spec/factories/static_page/section_paragraphs.rb
+++ b/backend/spec/factories/static_page/section_paragraphs.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: static_page_section_paragraphs
+#
+#  id                :bigint           not null, primary key
+#  section_id        :bigint           not null
+#  image_position    :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  text              :text
+#  image_credits     :string
+#
 FactoryBot.define do
   factory :static_page_section_paragraph, class: "StaticPage::SectionParagraph" do
     section factory: :static_page_section

--- a/backend/spec/factories/static_page/sections.rb
+++ b/backend/spec/factories/static_page/sections.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: static_page_sections
+#
+#  id                 :bigint           not null, primary key
+#  static_page_id     :bigint           not null
+#  position           :integer          not null
+#  slug               :string
+#  section_type       :string           not null
+#  title_size         :integer          default(2)
+#  show_at_navigation :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  title              :string
+#
 FactoryBot.define do
   factory :static_page_section, class: "StaticPage::Section" do
     static_page

--- a/backend/spec/fixtures/snapshots/api/v1/get_static_page.json
+++ b/backend/spec/fixtures/snapshots/api/v1/get_static_page.json
@@ -1,0 +1,165 @@
+{
+  "data": {
+    "id": "131",
+    "type": "static_page_bases",
+    "attributes": {
+      "title": "Enim repellat pariatur est.",
+      "slug": "StaticPage-1",
+      "image": {
+        "small": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2dEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--48af5b88ef4c3e765afddcd55841e19f0ecd4dcc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg",
+        "medium": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2dEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--48af5b88ef4c3e765afddcd55841e19f0ecd4dcc/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg",
+        "original": "http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2dEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--48af5b88ef4c3e765afddcd55841e19f0ecd4dcc/picture.jpg"
+      },
+      "image_credits": "Enim repellat pariatur est.",
+      "image_credits_url": "http://kutch-spencer.com/moises"
+    },
+    "relationships": {
+      "sections": {
+        "data": [
+          {
+            "id": "242",
+            "type": "static_page_sections"
+          },
+          {
+            "id": "243",
+            "type": "static_page_sections"
+          },
+          {
+            "id": "244",
+            "type": "static_page_sections"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "242",
+      "type": "static_page_sections",
+      "attributes": {
+        "title": "Enim repellat pariatur est.",
+        "slug": "StaticPageSection-1",
+        "title_size": 4,
+        "section_type": "paragraph",
+        "show_at_navigation": true,
+        "position": 1
+      },
+      "relationships": {
+        "section_paragraph": {
+          "data": {
+            "id": "92",
+            "type": "static_page_section_paragraphs"
+          }
+        },
+        "section_items": {
+          "data": [
+
+          ]
+        },
+        "section_references": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "92",
+      "type": "static_page_section_paragraphs",
+      "attributes": {
+        "text": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
+        "image": {
+          "small": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2tEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--327ad2335142bf650ad79878dd5d772ac7ab3ad0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg",
+          "medium": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2tEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--327ad2335142bf650ad79878dd5d772ac7ab3ad0/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg",
+          "original": "http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2tEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--327ad2335142bf650ad79878dd5d772ac7ab3ad0/picture.jpg"
+        },
+        "image_credits": "Enim repellat pariatur est.",
+        "image_credits_url": "http://kutch-spencer.com/moises",
+        "image_position": "right"
+      }
+    },
+    {
+      "id": "243",
+      "type": "static_page_sections",
+      "attributes": {
+        "title": "Placeat commodi libero et.",
+        "slug": "StaticPageSection-2",
+        "title_size": 1,
+        "section_type": "items",
+        "show_at_navigation": true,
+        "position": 1
+      },
+      "relationships": {
+        "section_paragraph": {
+          "data": null
+        },
+        "section_items": {
+          "data": [
+            {
+              "id": "80",
+              "type": "static_page_section_items"
+            }
+          ]
+        },
+        "section_references": {
+          "data": [
+
+          ]
+        }
+      }
+    },
+    {
+      "id": "80",
+      "type": "static_page_section_items",
+      "attributes": {
+        "title": "Enim repellat pariatur est.",
+        "description": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
+        "image": {
+          "small": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa29EIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f1860fe7aa5060553f54a14e7176e53e552521e4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg",
+          "medium": "http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa29EIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f1860fe7aa5060553f54a14e7176e53e552521e4/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg",
+          "original": "http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa29EIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f1860fe7aa5060553f54a14e7176e53e552521e4/picture.jpg"
+        },
+        "position": 1
+      }
+    },
+    {
+      "id": "244",
+      "type": "static_page_sections",
+      "attributes": {
+        "title": "Et quaerat omnis veniam.",
+        "slug": "StaticPageSection-3",
+        "title_size": 3,
+        "section_type": "references",
+        "show_at_navigation": false,
+        "position": 1
+      },
+      "relationships": {
+        "section_paragraph": {
+          "data": null
+        },
+        "section_items": {
+          "data": [
+
+          ]
+        },
+        "section_references": {
+          "data": [
+            {
+              "id": "80",
+              "type": "static_page_section_references"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "80",
+      "type": "static_page_section_references",
+      "attributes": {
+        "slug": "StaticPageReference-1",
+        "text": "Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.",
+        "position": 1
+      }
+    }
+  ]
+}

--- a/backend/spec/models/static_page/base_spec.rb
+++ b/backend/spec/models/static_page/base_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_bases
+#
+#  id                :bigint           not null, primary key
+#  slug              :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  title             :string
+#  image_credits     :string
+#
 require "rails_helper"
 
 RSpec.describe StaticPage::Base, type: :model do

--- a/backend/spec/models/static_page/section_item_spec.rb
+++ b/backend/spec/models/static_page/section_item_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_section_items
+#
+#  id          :bigint           not null, primary key
+#  section_id  :bigint           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  title       :string
+#  description :text
+#
 require "rails_helper"
 
 RSpec.describe StaticPage::SectionItem, type: :model do

--- a/backend/spec/models/static_page/section_paragraph_spec.rb
+++ b/backend/spec/models/static_page/section_paragraph_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: static_page_section_paragraphs
+#
+#  id                :bigint           not null, primary key
+#  section_id        :bigint           not null
+#  image_position    :string           not null
+#  image_credits_url :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  text              :text
+#  image_credits     :string
+#
 require "rails_helper"
 
 RSpec.describe StaticPage::SectionParagraph, type: :model do

--- a/backend/spec/models/static_page/section_reference_spec.rb
+++ b/backend/spec/models/static_page/section_reference_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: static_page_section_references
+#
+#  id         :bigint           not null, primary key
+#  section_id :bigint           not null
+#  slug       :string
+#  position   :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  text       :text
+#
 require "rails_helper"
 
 RSpec.describe StaticPage::SectionReference, type: :model do

--- a/backend/spec/models/static_page/section_spec.rb
+++ b/backend/spec/models/static_page/section_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: static_page_sections
+#
+#  id                 :bigint           not null, primary key
+#  static_page_id     :bigint           not null
+#  position           :integer          not null
+#  slug               :string
+#  section_type       :string           not null
+#  title_size         :integer          default(2)
+#  show_at_navigation :boolean          default(FALSE), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  title              :string
+#
 require "rails_helper"
 
 RSpec.describe StaticPage::Section, type: :model do

--- a/backend/spec/requests/api/v1/static_pages_spec.rb
+++ b/backend/spec/requests/api/v1/static_pages_spec.rb
@@ -1,0 +1,35 @@
+require "swagger_helper"
+
+RSpec.describe "API V1 Static Pages", type: :request do
+  path "/api/static_pages/{slug}" do
+    get "Get static page with appropriate slug" do
+      tags "StaticPage"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :slug, in: :path, type: :string, description: "Slug of static page", required: true
+      parameter name: :locale, in: :query, type: :string, description: "Used language. Default: en", required: false
+
+      let!(:static_page) { create :static_page }
+      let!(:static_page_section_paragraph) do
+        create :static_page_section_paragraph, section: create(:static_page_section, section_type: :paragraph, static_page: static_page)
+      end
+      let!(:static_page_section_item) do
+        create :static_page_section_item, section: create(:static_page_section, section_type: :items, static_page: static_page)
+      end
+      let!(:static_page_section_reference) do
+        create :static_page_section_reference, section: create(:static_page_section, section_type: :references, static_page: static_page)
+      end
+      let(:slug) { static_page.slug }
+
+      it_behaves_like "with not found error"
+
+      response "200", :success do
+        run_test!
+
+        it "matches snapshot", generate_swagger_example: true do
+          expect(response.body).to match_snapshot("api/v1/get_static_page")
+        end
+      end
+    end
+  end
+end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -47,7 +47,7 @@ paths:
                   data_units: molestiae
                   processing: molestiae
                   description: Et quaerat omnis veniam.
-                  id: 539
+                  id: 73
                   layer_group_id:
                   slug: Layer-3
                   layer_type:
@@ -60,8 +60,8 @@ paths:
                   interactivity:
                   opacity: 25.0
                   query: Et quaerat omnis veniam.
-                  created_at: '2023-04-12T14:23:02.174+02:00'
-                  updated_at: '2023-04-12T14:23:02.176+02:00'
+                  created_at: '2023-04-18T14:52:25.141+02:00'
+                  updated_at: '2023-04-18T14:52:25.143+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -91,7 +91,7 @@ paths:
                   data_units: cum
                   processing: cum
                   description: Placeat commodi libero et.
-                  id: 538
+                  id: 72
                   layer_group_id:
                   slug: Layer-2
                   layer_type:
@@ -104,8 +104,8 @@ paths:
                   interactivity:
                   opacity: 41.0
                   query: Placeat commodi libero et.
-                  created_at: '2023-04-12T14:23:02.171+02:00'
-                  updated_at: '2023-04-12T14:23:02.172+02:00'
+                  created_at: '2023-04-18T14:52:25.137+02:00'
+                  updated_at: '2023-04-18T14:52:25.139+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -135,7 +135,7 @@ paths:
                   data_units: voluptatem
                   processing: voluptatem
                   description: Enim repellat pariatur est.
-                  id: 537
+                  id: 71
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -148,8 +148,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-12T14:23:02.167+02:00'
-                  updated_at: '2023-04-12T14:23:02.169+02:00'
+                  created_at: '2023-04-18T14:52:25.133+02:00'
+                  updated_at: '2023-04-18T14:52:25.135+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -208,7 +208,7 @@ paths:
                   data_units:
                   processing:
                   description:
-                  id: 541
+                  id: 75
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -221,8 +221,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-12T14:23:02.194+02:00'
-                  updated_at: '2023-04-12T14:23:02.196+02:00'
+                  created_at: '2023-04-18T14:52:25.168+02:00'
+                  updated_at: '2023-04-18T14:52:25.171+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -299,7 +299,7 @@ paths:
                   data_units: voluptatem
                   processing: voluptatem
                   description: Enim repellat pariatur est.
-                  id: 549
+                  id: 83
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -312,8 +312,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-12T14:23:02.256+02:00'
-                  updated_at: '2023-04-12T14:23:02.258+02:00'
+                  created_at: '2023-04-18T14:52:25.245+02:00'
+                  updated_at: '2023-04-18T14:52:25.247+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -379,7 +379,7 @@ paths:
                   data_units:
                   processing:
                   description:
-                  id: 553
+                  id: 87
                   layer_group_id:
                   slug: Layer-1
                   layer_type:
@@ -392,8 +392,8 @@ paths:
                   interactivity:
                   opacity: 38.0
                   query: Enim repellat pariatur est.
-                  created_at: '2023-04-12T14:23:02.299+02:00'
-                  updated_at: '2023-04-12T14:23:02.305+02:00'
+                  created_at: '2023-04-18T14:52:25.311+02:00'
+                  updated_at: '2023-04-18T14:52:25.319+02:00'
                   locate_layer: false
                   icon_class:
                   published: true
@@ -449,7 +449,7 @@ paths:
                 - name: AAA
                   linkback_text: Enim repellat pariatur. Earum modi eos. Libero tempora
                     exercitationem.
-                  id: 277
+                  id: 60
                   color: "#ffdbdb"
                   subdomain: voluptatem
                   has_analysis: true
@@ -466,7 +466,7 @@ paths:
                 - name: BBB
                   linkback_text: Placeat commodi libero. Quo recusandae repellat.
                     Sunt commodi tempore.
-                  id: 278
+                  id: 61
                   color: "#eaf1ea"
                   subdomain: cum
                   has_analysis: true
@@ -492,7 +492,7 @@ paths:
           content:
             application/json:
               example:
-                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozNSwiZXhwIjoxNjgxMzg4NTgyfQ.jvA6mmsbZS-N7BYkywmaCCOZtbAZI6RUo2bzVF54tFU
+                auth_token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyNSwiZXhwIjoxNjgxOTA4NzQ1fQ.ozkx6iRsce9idGU-Y4U-4Holj-StSZf0Qb7tgWk80pE
         '401':
           description: Unauthorized
           content:
@@ -532,7 +532,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '43'
+                - id: '31'
                   type: categories
                   attributes:
                     name: voluptatem
@@ -542,7 +542,7 @@ paths:
                   relationships:
                     indicators:
                       data: []
-                - id: '44'
+                - id: '32'
                   type: categories
                   attributes:
                     name: cum
@@ -552,7 +552,7 @@ paths:
                   relationships:
                     indicators:
                       data: []
-                - id: '45'
+                - id: '33'
                   type: categories
                   attributes:
                     name: molestiae
@@ -577,31 +577,31 @@ paths:
             application/json:
               example:
                 data:
-                  id: '18'
+                  id: '16'
                   type: feedbacks
                   attributes:
                     language: en
-                    created_at: '2023-04-12T14:23:02.689+02:00'
-                    updated_at: '2023-04-12T14:23:02.689+02:00'
+                    created_at: '2023-04-18T14:52:25.739+02:00'
+                    updated_at: '2023-04-18T14:52:25.739+02:00'
                   relationships:
                     feedback_fields:
                       data:
-                      - id: '50'
+                      - id: '36'
                         type: feedback_fields
-                      - id: '51'
+                      - id: '37'
                         type: feedback_fields
-                      - id: '52'
+                      - id: '38'
                         type: feedback_fields
-                      - id: '53'
+                      - id: '39'
                         type: feedback_fields
-                      - id: '54'
+                      - id: '40'
                         type: feedback_fields
-                      - id: '55'
+                      - id: '41'
                         type: feedback_fields
-                      - id: '56'
+                      - id: '42'
                         type: feedback_fields
                 included:
-                - id: '50'
+                - id: '36'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -609,18 +609,18 @@ paths:
                     answer:
                       slug: red
                       value: Red
-                    created_at: '2023-04-12T14:23:02.691+02:00'
-                    updated_at: '2023-04-12T14:23:02.691+02:00'
+                    created_at: '2023-04-18T14:52:25.740+02:00'
+                    updated_at: '2023-04-18T14:52:25.740+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '51'
+                - id: '37'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: multiple_choice
@@ -632,18 +632,18 @@ paths:
                       value:
                       - Green
                       - Yellow
-                    created_at: '2023-04-12T14:23:02.691+02:00'
-                    updated_at: '2023-04-12T14:23:02.691+02:00'
+                    created_at: '2023-04-18T14:52:25.741+02:00'
+                    updated_at: '2023-04-18T14:52:25.741+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '52'
+                - id: '38'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: boolean_choice
@@ -651,18 +651,18 @@ paths:
                     answer:
                       slug: 'true'
                       value: true
-                    created_at: '2023-04-12T14:23:02.693+02:00'
-                    updated_at: '2023-04-12T14:23:02.693+02:00'
+                    created_at: '2023-04-18T14:52:25.741+02:00'
+                    updated_at: '2023-04-18T14:52:25.741+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '53'
+                - id: '39'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: free_answer
@@ -670,39 +670,39 @@ paths:
                     answer:
                       slug: i-don-t-know
                       value: I don't know
-                    created_at: '2023-04-12T14:23:02.694+02:00'
-                    updated_at: '2023-04-12T14:23:02.694+02:00'
+                    created_at: '2023-04-18T14:52:25.742+02:00'
+                    updated_at: '2023-04-18T14:52:25.742+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data: []
-                - id: '54'
+                - id: '40'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: rating
                     question: Color preferences
                     answer:
-                    created_at: '2023-04-12T14:23:02.695+02:00'
-                    updated_at: '2023-04-12T14:23:02.695+02:00'
+                    created_at: '2023-04-18T14:52:25.743+02:00'
+                    updated_at: '2023-04-18T14:52:25.743+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
                     children:
                       data:
-                      - id: '55'
+                      - id: '41'
                         type: feedback_fields
-                      - id: '56'
+                      - id: '42'
                         type: feedback_fields
-                - id: '55'
+                - id: '41'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -710,20 +710,20 @@ paths:
                     answer:
                       slug: '3'
                       value: 3
-                    created_at: '2023-04-12T14:23:02.695+02:00'
-                    updated_at: '2023-04-12T14:23:02.695+02:00'
+                    created_at: '2023-04-18T14:52:25.744+02:00'
+                    updated_at: '2023-04-18T14:52:25.744+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
-                        id: '54'
+                        id: '40'
                         type: feedback_fields
                     children:
                       data: []
-                - id: '56'
+                - id: '42'
                   type: feedback_fields
                   attributes:
                     feedback_field_type: single_choice
@@ -731,16 +731,16 @@ paths:
                     answer:
                       slug: '5'
                       value: 5
-                    created_at: '2023-04-12T14:23:02.696+02:00'
-                    updated_at: '2023-04-12T14:23:02.696+02:00'
+                    created_at: '2023-04-18T14:52:25.745+02:00'
+                    updated_at: '2023-04-18T14:52:25.745+02:00'
                   relationships:
                     feedback:
                       data:
-                        id: '18'
+                        id: '16'
                         type: feedbacks
                     parent:
                       data:
-                        id: '54'
+                        id: '40'
                         type: feedback_fields
                     children:
                       data: []
@@ -822,33 +822,33 @@ paths:
             application/json:
               example:
                 data:
-                  id: '55'
+                  id: '15'
                   type: homepages
                   attributes:
                     title: Enim repellat pariatur est.
                     subtitle: Enim repellat pariatur est.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbElDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--6d47a726cc569e56ea14c0a3e292a0187b1c6d1c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbElDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--6d47a726cc569e56ea14c0a3e292a0187b1c6d1c/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbElDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--6d47a726cc569e56ea14c0a3e292a0187b1c6d1c/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4d108df9c8864b64941833f5a51703fd546d4e78/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4d108df9c8864b64941833f5a51703fd546d4e78/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4d108df9c8864b64941833f5a51703fd546d4e78/picture.jpg
                     credits: Enim repellat pariatur est.
                     credits_url: http://kutch-spencer.com/moises
                   relationships:
                     homepage_journey:
                       data:
-                        id: '56'
+                        id: '15'
                         type: homepage_journeys
                     homepage_sections:
                       data:
-                      - id: '36'
+                      - id: '10'
                         type: homepage_sections
                 included:
-                - id: '56'
+                - id: '15'
                   type: homepage_journeys
                   attributes:
                     title: Enim repellat pariatur est.
                     position: 0
-                - id: '36'
+                - id: '10'
                   type: homepage_sections
                   attributes:
                     title: Enim repellat pariatur est.
@@ -861,9 +861,9 @@ paths:
                     background_color: "#ffdbdb"
                     position: 1
                     image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbE1DIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9142affcdb43c2df4ef2c2f875cebe035533cfc9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbE1DIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9142affcdb43c2df4ef2c2f875cebe035533cfc9/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbE1DIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9142affcdb43c2df4ef2c2f875cebe035533cfc9/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--56bc62927221d1c5b83e6073440c5a1900e04211/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--56bc62927221d1c5b83e6073440c5a1900e04211/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBazREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--56bc62927221d1c5b83e6073440c5a1900e04211/picture.jpg
         '404':
           description: Site scope does not have homepage
           content:
@@ -891,7 +891,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '23'
+                - id: '17'
                   type: indicators
                   attributes:
                     name: voluptatem
@@ -905,9 +905,9 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '49'
+                        id: '37'
                         type: categories
-                - id: '24'
+                - id: '18'
                   type: indicators
                   attributes:
                     name: cum
@@ -921,9 +921,9 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '50'
+                        id: '38'
                         type: categories
-                - id: '25'
+                - id: '19'
                   type: indicators
                   attributes:
                     name: molestiae
@@ -937,10 +937,10 @@ paths:
                       data: []
                     category:
                       data:
-                        id: '51'
+                        id: '39'
                         type: categories
                 included:
-                - id: '49'
+                - id: '37'
                   type: categories
                   attributes:
                     name: voluptatem
@@ -950,9 +950,9 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '23'
+                      - id: '17'
                         type: indicators
-                - id: '50'
+                - id: '38'
                   type: categories
                   attributes:
                     name: cum
@@ -962,9 +962,9 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '24'
+                      - id: '18'
                         type: indicators
-                - id: '51'
+                - id: '39'
                   type: categories
                   attributes:
                     name: molestiae
@@ -974,7 +974,7 @@ paths:
                   relationships:
                     indicators:
                       data:
-                      - id: '25'
+                      - id: '19'
                         type: indicators
                 meta:
                   total_indicators: 3
@@ -997,65 +997,65 @@ paths:
             application/json:
               example:
                 data:
-                - id: '136'
+                - id: '89'
                   type: journeys
                   attributes:
                     title: Enim repellat pariatur est.
                     subtitle: Enim repellat pariatur est.
                     theme: Enim repellat pariatur est.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1b361dd3362ad1dc9f57caf2d5ad93438361b4fe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1b361dd3362ad1dc9f57caf2d5ad93438361b4fe/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1b361dd3362ad1dc9f57caf2d5ad93438361b4fe/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--82e5b5be6ef232ce7ae55595eaff6a840b3256b2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--82e5b5be6ef232ce7ae55595eaff6a840b3256b2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--82e5b5be6ef232ce7ae55595eaff6a840b3256b2/picture.jpg
                     credits: Enim repellat pariatur est.
                     credits_url: http://kutch-spencer.com/moises
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '308'
+                      - id: '202'
                         type: journey_steps
-                      - id: '309'
+                      - id: '203'
                         type: journey_steps
-                - id: '137'
+                - id: '90'
                   type: journeys
                   attributes:
                     title: Placeat commodi libero et.
                     subtitle: Placeat commodi libero et.
                     theme: Placeat commodi libero et.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbVFDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1ce26825786cc6b1aa3ad8d262e387f9f69b9923/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbVFDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1ce26825786cc6b1aa3ad8d262e387f9f69b9923/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbVFDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1ce26825786cc6b1aa3ad8d262e387f9f69b9923/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbDhEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5ae77f3977bd0aac8bebefd2bf848219d73dd778/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbDhEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5ae77f3977bd0aac8bebefd2bf848219d73dd778/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbDhEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5ae77f3977bd0aac8bebefd2bf848219d73dd778/picture.jpg
                     credits: Placeat commodi libero et.
                     credits_url: http://bartoletti.com/jeremiah_cronin
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '310'
+                      - id: '204'
                         type: journey_steps
-                      - id: '311'
+                      - id: '205'
                         type: journey_steps
-                - id: '138'
+                - id: '91'
                   type: journeys
                   attributes:
                     title: Et quaerat omnis veniam.
                     subtitle: Et quaerat omnis veniam.
                     theme: Et quaerat omnis veniam.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbWNDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--520af4b39cfa9e8e1118b1c508175d0342a5f3e7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbWNDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--520af4b39cfa9e8e1118b1c508175d0342a5f3e7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbWNDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--520af4b39cfa9e8e1118b1c508175d0342a5f3e7/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUlEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--92e45f139c7eaa1cb21e2c211340f81e5d9a1d5b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUlEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--92e45f139c7eaa1cb21e2c211340f81e5d9a1d5b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbUlEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--92e45f139c7eaa1cb21e2c211340f81e5d9a1d5b/picture.jpg
                     credits: Et quaerat omnis veniam.
                     credits_url: http://hane.com/jules
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '313'
+                      - id: '207'
                         type: journey_steps
-                      - id: '312'
+                      - id: '206'
                         type: journey_steps
                 meta:
                   total: 3
@@ -1092,32 +1092,32 @@ paths:
             application/json:
               example:
                 data:
-                  id: '157'
+                  id: '110'
                   type: journeys
                   attributes:
                     title: Autem et et ex.
                     subtitle: Autem et et ex.
                     theme: Autem et et ex.
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcVlDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2545d63d8134eb53e060481de6b87addfd7890ab/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcVlDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2545d63d8134eb53e060481de6b87addfd7890ab/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcVlDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--2545d63d8134eb53e060481de6b87addfd7890ab/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f29b463988d9aafd11be7852acaa80b3c0617deb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f29b463988d9aafd11be7852acaa80b3c0617deb/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f29b463988d9aafd11be7852acaa80b3c0617deb/picture.jpg
                     credits: Autem et et ex.
                     credits_url: http://jacobson.biz/everett
                     published: true
                   relationships:
                     journey_steps:
                       data:
-                      - id: '351'
+                      - id: '245'
                         type: journey_steps
-                      - id: '348'
+                      - id: '242'
                         type: journey_steps
-                      - id: '357'
+                      - id: '251'
                         type: journey_steps
-                      - id: '354'
+                      - id: '248'
                         type: journey_steps
                 included:
-                - id: '351'
+                - id: '245'
                   type: journey_steps
                   attributes:
                     step_type: conclusion
@@ -1130,10 +1130,10 @@ paths:
                     credits_url: http://keebler.info/daine
                     background_color: "#c2e0e0"
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcDBDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b8f3b4495a932a129f53782dd9ccac0a6092bd93/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcDBDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b8f3b4495a932a129f53782dd9ccac0a6092bd93/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcDBDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b8f3b4495a932a129f53782dd9ccac0a6092bd93/picture.jpg
-                - id: '348'
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ba98fff2ed4cc19d60890eab2b91091e8892249b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ba98fff2ed4cc19d60890eab2b91091e8892249b/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ba98fff2ed4cc19d60890eab2b91091e8892249b/picture.jpg
+                - id: '242'
                   type: journey_steps
                   attributes:
                     step_type: landing
@@ -1143,10 +1143,10 @@ paths:
                     credits: Et quaerat omnis veniam.
                     credits_url: http://hane.com/jules
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d4ce8a3b0dca31ee319d4b6fce2463934f4a53ac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d4ce8a3b0dca31ee319d4b6fce2463934f4a53ac/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcGtDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d4ce8a3b0dca31ee319d4b6fce2463934f4a53ac/picture.jpg
-                - id: '357'
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcFFEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9503fa0ac6c5fc7734fd987d11d31067848a912e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcFFEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9503fa0ac6c5fc7734fd987d11d31067848a912e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcFFEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9503fa0ac6c5fc7734fd987d11d31067848a912e/picture.jpg
+                - id: '251'
                   type: journey_steps
                   attributes:
                     step_type: embed
@@ -1159,7 +1159,7 @@ paths:
                     mask_sql: Eum consequuntur adipisci non.
                     map_url: http://lind.name/alana
                     embedded_map_url: http://lind.name/alana
-                - id: '354'
+                - id: '248'
                   type: journey_steps
                   attributes:
                     step_type: chapter
@@ -1171,9 +1171,9 @@ paths:
                     credits_url: http://ritchie.com/jame
                     background_color: "#bf40bf"
                     background_image:
-                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--792ac19774147ebf5cbba04a9de95173a5968f9e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
-                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--792ac19774147ebf5cbba04a9de95173a5968f9e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
-                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcUVDIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--792ac19774147ebf5cbba04a9de95173a5968f9e/picture.jpg
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9aa33732f66991a4867a951943dcd75790af4789/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9aa33732f66991a4867a951943dcd75790af4789/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcHdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9aa33732f66991a4867a951943dcd75790af4789/picture.jpg
   "/api/layer-groups":
     get:
       summary: Get list of layer groups
@@ -1199,7 +1199,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '72'
+                - id: '46'
                   type: layer_groups
                   attributes:
                     name: voluptatem
@@ -1215,7 +1215,7 @@ paths:
                   relationships:
                     super_group:
                       data:
-                - id: '73'
+                - id: '47'
                   type: layer_groups
                   attributes:
                     name: cum
@@ -1232,7 +1232,7 @@ paths:
                   relationships:
                     super_group:
                       data:
-                - id: '74'
+                - id: '48'
                   type: layer_groups
                   attributes:
                     name: molestiae
@@ -1275,7 +1275,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '559'
+                - id: '93'
                   type: layers
                   attributes:
                     name: molestiae
@@ -1309,17 +1309,17 @@ paths:
                   relationships:
                     layer_group:
                       data:
-                        id: '81'
+                        id: '55'
                         type: layer_groups
                     sources:
                       data: []
                     agrupation:
                       data:
-                        id: 50
-                        layer_id: 559
-                        layer_group_id: 81
+                        id: 32
+                        layer_id: 93
+                        layer_group_id: 55
                         active: false
-                - id: '557'
+                - id: '91'
                   type: layers
                   attributes:
                     name: voluptatem
@@ -1353,17 +1353,17 @@ paths:
                   relationships:
                     layer_group:
                       data:
-                        id: '81'
+                        id: '55'
                         type: layer_groups
                     sources:
                       data: []
                     agrupation:
                       data:
-                        id: 48
-                        layer_id: 557
-                        layer_group_id: 81
+                        id: 30
+                        layer_id: 91
+                        layer_group_id: 55
                         active: false
-                - id: '558'
+                - id: '92'
                   type: layers
                   attributes:
                     name: cum
@@ -1397,15 +1397,15 @@ paths:
                   relationships:
                     layer_group:
                       data:
-                        id: '81'
+                        id: '55'
                         type: layer_groups
                     sources:
                       data: []
                     agrupation:
                       data:
-                        id: 49
-                        layer_id: 558
-                        layer_group_id: 81
+                        id: 31
+                        layer_id: 92
+                        layer_group_id: 55
                         active: false
                 meta:
                   total_layers: 3
@@ -1461,21 +1461,21 @@ paths:
             application/json:
               example:
                 data:
-                - id: '23'
+                - id: '17'
                   type: map_menu_entries
                   attributes:
                     label: Otha Kemmer
                     link: http://kutch-spencer.com/moises
                     position: 38
                     ancestry:
-                - id: '24'
+                - id: '18'
                   type: map_menu_entries
                   attributes:
                     label: Msgr. Genaro Cronin
                     link: http://bartoletti.com/jeremiah_cronin
                     position: 41
                     ancestry:
-                - id: '25'
+                - id: '19'
                   type: map_menu_entries
                   attributes:
                     label: Raymon Wisoky
@@ -1507,7 +1507,7 @@ paths:
             application/json:
               example:
                 data:
-                - id: '36'
+                - id: '24'
                   type: models
                   attributes:
                     name: voluptatem
@@ -1523,7 +1523,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '37'
+                - id: '25'
                   type: models
                   attributes:
                     name: cum
@@ -1539,7 +1539,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '38'
+                - id: '26'
                   type: models
                   attributes:
                     name: molestiae
@@ -1555,7 +1555,7 @@ paths:
                         type: site_scopes
                     indicators:
                       data: []
-                - id: '39'
+                - id: '27'
                   type: models
                   attributes:
                     name: quos
@@ -1679,12 +1679,12 @@ paths:
           content:
             application/json:
               example:
-                id: 6
-                image_data: '{"id":"9d443bba4f97a64210987b076a13be41.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
-                created_at: '2023-04-12T14:23:16.168+02:00'
-                updated_at: '2023-04-12T14:23:16.169+02:00'
-                url: "/uploads/store/9d443bba4f97a64210987b076a13be41.jpg"
-                image_url: "/uploads/store/9d443bba4f97a64210987b076a13be41.jpg"
+                id: 4
+                image_data: '{"id":"35c9d6410d5f7a3ce17866564bce3c51.jpg","storage":"store","metadata":{"filename":"picture.jpg","size":32326,"mime_type":null}}'
+                created_at: '2023-04-18T14:52:35.751+02:00'
+                updated_at: '2023-04-18T14:52:35.753+02:00'
+                url: "/uploads/store/35c9d6410d5f7a3ce17866564bce3c51.jpg"
+                image_url: "/uploads/store/35c9d6410d5f7a3ce17866564bce3c51.jpg"
         '401':
           description: Authentication failed
           content:
@@ -1766,7 +1766,7 @@ paths:
             application/json:
               example:
                 data:
-                  id: '10'
+                  id: '6'
                   type: share_urls
                   attributes:
                     uid: '12345'
@@ -1788,7 +1788,7 @@ paths:
           content:
             application/json:
               example:
-                uid: 310364edabb375f9af3d
+                uid: 192477ddf2cca7b15a8f
   "/api/sites":
     get:
       summary: Get list of all site scopes
@@ -1899,15 +1899,151 @@ paths:
                   relationships:
                     site_pages:
                       data:
-                      - id: '13'
+                      - id: '11'
                         type: site_pages
                 included:
-                - id: '13'
+                - id: '11'
                   type: site_pages
                   attributes:
                     title: voluptatem
                     priority: 38
                     url: "/contents/SitePage-1"
+  "/api/static_pages/{slug}":
+    get:
+      summary: Get static page with appropriate slug
+      tags:
+      - StaticPage
+      parameters:
+      - name: slug
+        in: path
+        description: Slug of static page
+        required: true
+        schema:
+          type: string
+      - name: locale
+        in: query
+        description: 'Used language. Default: en'
+        required: false
+        schema:
+          type: string
+      responses:
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              example:
+                errors:
+                - status: '404'
+                  title: Record not found
+        '200':
+          description: success
+          content:
+            application/json:
+              example:
+                data:
+                  id: '134'
+                  type: static_page_bases
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    slug: StaticPage-1
+                    image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdXdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--06e92b95a80e7b634281c94a47222e484481e8a2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdXdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--06e92b95a80e7b634281c94a47222e484481e8a2/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdXdEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--06e92b95a80e7b634281c94a47222e484481e8a2/picture.jpg
+                    image_credits: Enim repellat pariatur est.
+                    image_credits_url: http://kutch-spencer.com/moises
+                  relationships:
+                    sections:
+                      data:
+                      - id: '251'
+                        type: static_page_sections
+                      - id: '252'
+                        type: static_page_sections
+                      - id: '253'
+                        type: static_page_sections
+                included:
+                - id: '251'
+                  type: static_page_sections
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    slug: StaticPageSection-1
+                    title_size: 4
+                    section_type: paragraph
+                    show_at_navigation: true
+                    position: 1
+                  relationships:
+                    section_paragraph:
+                      data:
+                        id: '95'
+                        type: static_page_section_paragraphs
+                    section_items:
+                      data: []
+                    section_references:
+                      data: []
+                - id: '95'
+                  type: static_page_section_paragraphs
+                  attributes:
+                    text: Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.
+                    image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--18f48802e90d9dad7c7009048f1a82ea057b33e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--18f48802e90d9dad7c7009048f1a82ea057b33e3/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--18f48802e90d9dad7c7009048f1a82ea057b33e3/picture.jpg
+                    image_credits: Enim repellat pariatur est.
+                    image_credits_url: http://kutch-spencer.com/moises
+                    image_position: right
+                - id: '252'
+                  type: static_page_sections
+                  attributes:
+                    title: Placeat commodi libero et.
+                    slug: StaticPageSection-2
+                    title_size: 1
+                    section_type: items
+                    show_at_navigation: true
+                    position: 1
+                  relationships:
+                    section_paragraph:
+                      data:
+                    section_items:
+                      data:
+                      - id: '83'
+                        type: static_page_section_items
+                    section_references:
+                      data: []
+                - id: '83'
+                  type: static_page_section_items
+                  attributes:
+                    title: Enim repellat pariatur est.
+                    description: Enim repellat pariatur. Earum modi eos. Libero tempora
+                      exercitationem.
+                    image:
+                      small: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2ef32b69cb71e85a7c061b9259ba0becebbe80e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERJd01IZ3lNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--7be8b6f6018bc25ae287d258d8836839fa7642f1/picture.jpg
+                      medium: http://localhost:3000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2ef32b69cb71e85a7c061b9259ba0becebbe80e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2QzNKbGMybDZaVWtpRERnd01IZzRNREFHT3daVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--697714719ccce7b35c5f9a02aeef5bd517f3d81f/picture.jpg
+                      original: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdTREIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d2ef32b69cb71e85a7c061b9259ba0becebbe80e/picture.jpg
+                    position: 1
+                - id: '253'
+                  type: static_page_sections
+                  attributes:
+                    title: Et quaerat omnis veniam.
+                    slug: StaticPageSection-3
+                    title_size: 3
+                    section_type: references
+                    show_at_navigation: false
+                    position: 1
+                  relationships:
+                    section_paragraph:
+                      data:
+                    section_items:
+                      data: []
+                    section_references:
+                      data:
+                      - id: '83'
+                        type: static_page_section_references
+                - id: '83'
+                  type: static_page_section_references
+                  attributes:
+                    slug: StaticPageReference-1
+                    text: Enim repellat pariatur. Earum modi eos. Libero tempora exercitationem.
+                    position: 1
   "/users/me":
     get:
       summary: Obtains information about current user
@@ -1929,10 +2065,10 @@ paths:
           content:
             application/json:
               example:
-                id: 40
+                id: 30
                 email: person-1@example.com
-                created_at: '2023-04-12T14:23:16.393+02:00'
-                updated_at: '2023-04-12T14:23:16.393+02:00'
+                created_at: '2023-04-18T14:52:36.263+02:00'
+                updated_at: '2023-04-18T14:52:36.263+02:00'
                 first_name: Dawna
                 last_name: Block
                 phone: "(995) 001-7692 x452"
@@ -1962,9 +2098,9 @@ paths:
                 first_name: Jan
                 last_name: Kowalski
                 email: jankowalski@example.com
-                id: 42
-                created_at: '2023-04-12T14:23:16.427+02:00'
-                updated_at: '2023-04-12T14:23:16.437+02:00'
+                id: 32
+                created_at: '2023-04-18T14:52:36.291+02:00'
+                updated_at: '2023-04-18T14:52:36.299+02:00'
                 phone: "(995) 001-7692 x452"
                 organization: voluptatem
                 organization_role: voluptatem


### PR DESCRIPTION
API endpoint which allows to obtain information about Static page -- in our case about `About` page

## Testing instructions

Make sure that you have "some" data for Static Page. Open swagger documentation and provide `slug` of your static page as part of path. Double check that data returned via API corresponds to data visible at backoffice.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-190
