### PR TITLE
fix: Check if blob is variable before calling variant

### DIFF
--- a/backend/app/services/blobs/get_link.rb
+++ b/backend/app/services/blobs/get_link.rb
@@ -16,7 +16,7 @@ module Blobs
     private
 
     def modify(original_blob)
-      options.present? ? original_blob.variant(options) : original_blob
+      (options.present? && original_blob.variable?) ? original_blob.variant(options) : original_blob
     end
   end
 end

--- a/backend/app/views/admin/shared/_image_with_thumbnail.html.slim
+++ b/backend/app/views/admin/shared/_image_with_thumbnail.html.slim
@@ -5,7 +5,7 @@
 
 - if show_image
   = link_to url_for(blob_object)
-    = image_tag blob_object.variant(resize: "200x200"), class: "image-preview"
+    = image_tag (blob_object.variable? ? blob_object.variant(resize: "200x200") : blob_object), class: "image-preview", style: "max-width: 200px; max-height: 200px;"
 - if inside_has_many_block
   - f.input blob, as: :file, input_html: { accept: "image/*" }, required: required
 - else

--- a/backend/app/views/admin/shared/_preview.html.slim
+++ b/backend/app/views/admin/shared/_preview.html.slim
@@ -1,2 +1,2 @@
 = link_to url_for(blob)
-  = image_tag blob.variant(resize: "200x200")
+  = image_tag (blob.variable? ? blob.variant(resize: "200x200") : blob), style: "max-width: 200px; max-height: 200px;"


### PR DESCRIPTION
Minor fix which checks that `variant ` can be called on top of `blob`.