### PR TITLE
RA2-185: Allow to publish/unpublish Layers via Backoffice

### DIFF
--- a/backend/app/views/admin/layers/_form.html.slim
+++ b/backend/app/views/admin/layers/_form.html.slim
@@ -2,6 +2,7 @@
   = f.semantic_errors
   = f.inputs "Layer metadata" do
     = f.input :slug
+    = f.input :published
     = f.inputs "Translated fields" do
       = f.translated_inputs switch_locale: false do |ff|
         = ff.input :id, as: :hidden

--- a/backend/spec/systems/admin/layers_spec.rb
+++ b/backend/spec/systems/admin/layers_spec.rb
@@ -204,4 +204,34 @@ RSpec.describe "Admin: Layers", type: :system do
       expect(page).not_to have_text(layer.name)
     end
   end
+
+  describe "#publish" do
+    let!(:layer) { create :layer, published: false }
+
+    before do
+      visit admin_layer_path(layer)
+    end
+
+    it "allows to change layer to published" do
+      click_on "Publish Layer"
+
+      expect(page).to have_text("Layer was published!")
+      expect(layer.reload).to be_published
+    end
+  end
+
+  describe "#unpublish" do
+    let!(:layer) { create :layer, published: true }
+
+    before do
+      visit admin_layer_path(layer)
+    end
+
+    it "allows to change layer to published" do
+      click_on "Unpublish Layer"
+
+      expect(page).to have_text("Layer was marked as not published!")
+      expect(layer.reload).not_to be_published
+    end
+  end
 end


### PR DESCRIPTION
Enhancing Layer view at Backoffice with possibility to publish and unpublish Layers. There are specialized buttons for publishing/unpublishing layer at layer detail (top right of the screen). This change can be also done via create/edit form (right under slug is published checkbox).

## Testing instructions

Open backoffice and try to publish and unpublish Layer of your choice.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-185
