### PR TITLE
fix: API fetches translations in way that allows fallback to english

### DIFF
--- a/backend/app/controllers/api/v1/menu_entries_controller.rb
+++ b/backend/app/controllers/api/v1/menu_entries_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class MenuEntriesController < ApiController
       def index
-        menu_entries = MapMenuEntry.with_translations I18n.locale
+        menu_entries = MapMenuEntry.with_translations
         render json: menu_entries
       end
     end

--- a/backend/app/controllers/api/v1/models_controller.rb
+++ b/backend/app/controllers/api/v1/models_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ModelsController < ApiController
       def index
-        @models = Model.fetch_all(model_params).with_translations I18n.locale
+        @models = Model.fetch_all(model_params).with_translations
         render json: @models,
           meta: {total_models: @models.size},
           include: [:site_scopes, :indicators, "indicators.category"]

--- a/backend/app/controllers/api/v1/sites_controller.rb
+++ b/backend/app/controllers/api/v1/sites_controller.rb
@@ -4,7 +4,7 @@ module Api
       include SitesFilters
 
       def index
-        sites = SiteScope.with_translations I18n.locale
+        sites = SiteScope.with_translations
         render json: sites
       end
 

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -20,6 +20,6 @@ class Category < ApplicationRecord
   translation_class.validates_presence_of :name, if: -> { locale.to_s == I18n.default_locale.to_s }
 
   def self.fetch_all(options = {})
-    Category.with_translations I18n.locale
+    Category.with_translations
   end
 end

--- a/backend/app/models/indicator.rb
+++ b/backend/app/models/indicator.rb
@@ -28,6 +28,6 @@ class Indicator < ApplicationRecord
   acts_as_list scope: :category
 
   def self.fetch_all(options = {})
-    Indicator.with_translations I18n.locale
+    Indicator.with_translations
   end
 end

--- a/backend/app/models/layer.rb
+++ b/backend/app/models/layer.rb
@@ -122,7 +122,7 @@ class Layer < ApplicationRecord
     else
       1
     end
-    layers = Layer.with_translations(I18n.locale)
+    layers = Layer.with_translations
     layers.site(site_scope)
   end
 

--- a/backend/app/models/layer_group.rb
+++ b/backend/app/models/layer_group.rb
@@ -47,7 +47,7 @@ class LayerGroup < ApplicationRecord
     else
       1
     end
-    layer_groups = LayerGroup.with_translations(I18n.locale)
+    layer_groups = LayerGroup.with_translations
     layer_groups.site(site_scope)
   end
 


### PR DESCRIPTION
Minor fix which allows to fetch even fallback translations during data fetch used by API endpoints -- `with_translations I18n.locale` actually fetched data only for appropriate language and ignored fallback so I am getting rid of `I18n.locale` argument, which is not required here at all in the end.
