### PR TITLE
Journeys fixes

### DIFF
--- a/frontend/src/views/components/Journey/Chapter/component.tsx
+++ b/frontend/src/views/components/Journey/Chapter/component.tsx
@@ -27,7 +27,7 @@ const Chapter: React.FC<JourneyAttributes> = ({
   <div
     className="m-journey--chapter"
     // Fallback for old journeys with number masked directly on the image
-    {...(backgroundColor
+    {...(backgroundColor && backgroundColor !== '#000000'
       ? {}
       : { style: { backgroundImage: `url(${backgroundImage?.original})` } })}
   >
@@ -35,13 +35,15 @@ const Chapter: React.FC<JourneyAttributes> = ({
       <div
         className="chapter-number"
         style={{
-          background: `
+          background:
+            !backgroundImage?.original &&
+            `
               linear-gradient(0deg, ${hexToRGB(backgroundColor, 0.6)},${hexToRGB(
-            backgroundColor,
-            0.6,
-          )}), linear-gradient(0deg, ${backgroundColor}, ${backgroundColor}), linear-gradient(0deg, #000, #000), url(${
-            backgroundImage?.original
-          })
+              backgroundColor,
+              0.6,
+            )}), linear-gradient(0deg, ${backgroundColor}, ${backgroundColor}), linear-gradient(0deg, #000, #000), url(${
+              backgroundImage?.original
+            })
             `,
         }}
       >


### PR DESCRIPTION
Journeys fixes - Chapter number and layers in embed

- [x] Chapter background image for chapters that already had a number image shows now if the background color is black.

- [ ] Layers not showing on staging but they do on production

## Testing instructions

- Go to one of the chapter images that we already had (not custom). The number image should show correctly.

- Go to the Ethiopia embed maps. The layers should show.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-204?atlOrigin=eyJpIjoiZDFmZWY0OGE1NmIxNGQxMmIzYTUyZWMxNzllMWJlMGIiLCJwIjoiaiJ9
