### PR TITLE
RA2-210: Allow to delete Layer Groups with agrupations

### DIFF
--- a/backend/app/models/layer_group.rb
+++ b/backend/app/models/layer_group.rb
@@ -18,7 +18,7 @@
 #
 
 class LayerGroup < ApplicationRecord
-  has_many :agrupations
+  has_many :agrupations, dependent: :destroy
   has_many :layers, through: :agrupations
   belongs_to :super_group, class_name: "LayerGroup", optional: true
   has_many :sub_groups, class_name: "LayerGroup", foreign_key: :super_group_id, dependent: :nullify

--- a/backend/app/models/pdf_file.rb
+++ b/backend/app/models/pdf_file.rb
@@ -45,17 +45,8 @@ class PdfFile
         pdf.text "Layer: #{@layer["name"]}", size: 10
         pdf.move_down(5)
         pdf.font_size 8
-        pdf.text "Info: #{begin
-          JSON.parse(@layer["info"]).with_indifferent_access[:description]
-        rescue
-          @layer["info"]
-        end}"
+        pdf.text "Info: #{@layer["description"]}"
         pdf.move_down(5)
-        pdf.text "Source: #{begin
-          JSON.parse(@layer["info"]).with_indifferent_access[:source]
-        rescue
-          @layer["info"]
-        end}"
         pdf.move_down(10)
         pdf.table generated_table_data, width: pdf.bounds.width, row_colors: ["F6F6F6", "FFFFFF"], cell_style: {border_width: 0,
                                                                                                                 border_color: "F0F0F0",

--- a/backend/spec/requests/api/v1/layers_spec.rb
+++ b/backend/spec/requests/api/v1/layers_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe "API V1 Layer", type: :request do
 
       let(:default_site_scope) { create :site_scope, id: 1, name: "CIGRP" }
       let(:layer_group) { create :layer_group, site_scope: default_site_scope }
-      let(:layer) { create :layer, download: true, layer_groups: [layer_group] }
+      let(:source) { create :source }
+      let(:layer) { create :layer, download: true, layer_groups: [layer_group], sources: [source] }
       let(:stub_layer_zip) { "#{Rails.root}/downloads/#{layer.name.parameterize}-date-#{DateTime.now.to_date.to_s.parameterize}-main.zip" }
       let(:id) { layer.id }
 

--- a/backend/spec/systems/admin/layer_groups_spec.rb
+++ b/backend/spec/systems/admin/layer_groups_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe "Admin: Layer Groups", type: :system do
   end
 
   describe "#delete" do
-    let!(:layer_group) { create :layer_group, name: "Custom Name" }
+    let(:layer) { create :layer }
+    let!(:layer_group) { create :layer_group, name: "Custom Name", layers: [layer] }
 
     before do
       visit admin_layer_groups_path


### PR DESCRIPTION
Simple fix which makes it possible to delete Layer Groups which have agrupations.

I have also added extra stuff related to `info` as part of this PR --> discovered it is referenced during PDF generation so I am removing it from there.

## Testing instructions

Assign agrupation to Layer/Layer Group and after it is assigned, try to delete appropriate layer group.

## Tracking

https://vizzuality.atlassian.net/browse/RA2-210
