### PR TITLE
Fix atlas subdomain redirects

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,8 +39,8 @@ Below is a description of each of the keys.
 | `NEXT_PUBLIC_GOOGLE_ANALYTICS` | Optional − Google Analytics' measurement ID                                                                            |
 | `NEXT_PUBLIC_TRANSIFEX_TOKEN`  | Token needed for the transifex translation service                                                                     |
 | `NEXT_PUBLIC_TRANSIFEX_SECRET` | Secret needed for the transifex translation service                                                                    |
-| `NEXT_PUBLIC_STATIC_JOURNEYS`  | Optional − Temporary - Static journey API different from the Backend one but used on production   
-| `NEXT_PUBLIC_GOOGLE_API_KEY`   | Optional - Google API Key |
+| `NEXT_PUBLIC_STATIC_JOURNEYS`  | Optional − Temporary - Static journey API different from the Backend one but used on production                        |
+| `NEXT_PUBLIC_GOOGLE_API_KEY`   |  Optional - Google API Key                                                                                             |
 
 ### How to update the environment variables
 
@@ -58,7 +58,7 @@ The application is translated with the [Transifex Native](https://www.transifex.
 
 ### Initialization
 
-Transifex is initialized on the App.jsx file. A PseudoTranslationPolicy is provided on the development environment so we can see what translations are missing on the different languages directly on the platform on development.
+Transifex is initialized on the App.jsx file. A [PseudoTranslationPolicy](https://developers.transifex.com/docs/javascript-sdk-missing-translations#pseudo-translation) is provided on the development environment so we can see what translations are missing on the different languages directly on the platform on development.
 
 ### Scripts
 
@@ -133,6 +133,11 @@ const Component = () => {
   return translation;
 };
 ```
+
+## Subdomains
+
+The application has different subdomains that can be accessed through the map menu and only show the map page and a back link. E.g https://africa.resilienceatlas.org/
+These subdomains are configured on the backend as site_scope and we can emulate this url on the frontend with the URL parameter `?site_scope=site_scope_name`
 
 ## CI/CD
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from 'next/server';
-import { PORT } from 'state/utils/api';
 import { getSubdomainFromURL } from 'utilities/getSubdomain';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  const host = request.headers.get('host');
+
   // Only when the subdomain is set and the path is /, redirect to the map
-  if (!!getSubdomainFromURL(PORT) && request.nextUrl.pathname === '/') {
+  if (!!getSubdomainFromURL(host) && request.nextUrl.pathname === '/') {
     return NextResponse.redirect(new URL('/map', request.url));
   }
   // Only when the subdomain is set do not allow access
-  if (!!getSubdomainFromURL(PORT)) return NextResponse.redirect(new URL('/404', request.url));
+  if (!!getSubdomainFromURL(host)) return NextResponse.redirect(new URL('/404', request.url));
 }
 
 // See "Matching Paths" below to learn more

--- a/frontend/src/utilities/getSubdomain.ts
+++ b/frontend/src/utilities/getSubdomain.ts
@@ -6,7 +6,12 @@ export const getSubdomainFromURL = (url: string): string => {
   const host = url.replace(/(^http(s?):\/\/)|(\.com)$/g, '');
   const subdomain = host.split('.')[0];
   // If no subdomain is set or we're in localhost, return null
-  if (!subdomain || subdomain === 'www' || subdomain === 'localhost' || subdomain === 'staging') {
+  if (
+    !subdomain ||
+    subdomain === 'www' ||
+    subdomain.startsWith('localhost') ||
+    subdomain === 'staging'
+  ) {
     return null;
   }
   return subdomain;

--- a/frontend/src/views/components/Map/Toolbar/SearchArea/SearchArea.component.tsx
+++ b/frontend/src/views/components/Map/Toolbar/SearchArea/SearchArea.component.tsx
@@ -182,7 +182,7 @@ const SearchArea: React.FC<SearchAreaProps> = ({ fitBounds, onAfterChange }) => 
                     <strong>-3.7034, 40.4306</strong> (<T _str="comma and space" />)
                   </li>
                   <li className="--highlighted">
-                    <strong>-3.7034,40.4306</strong> (<T _str="only coma" />)
+                    <strong>-3.7034,40.4306</strong> (<T _str="only comma" />)
                   </li>
                   <li className="--highlighted">
                     <strong>-3.7034 40.4306</strong> (<T _str="only space" />)


### PR DESCRIPTION
Fix the redirects so that everytime we have the plain url it redirects to map

## Testing instructions

Go to any subdomain of the aplication. E.g.
africa.resilienceatlas.org it should redirect to the map page.

Attention: I don't think we can test this on staging. To test it on development you can use Chrome and append the subdomain: africa.localhost:3000

## Tracking

https://vizzuality.atlassian.net/browse/RA2-213?atlOrigin=eyJpIjoiMTZlNDA1ZGE3MDM3NDM0N2E0MzJhYmU2MzAyOGNiMjgiLCJwIjoiaiJ9

