### PR TITLE
Fix an issue that prevents the user from accessing the app on production

### DIFF
--- a/frontend/src/utilities/getSubdomain.ts
+++ b/frontend/src/utilities/getSubdomain.ts
@@ -8,9 +8,14 @@ export const getSubdomainFromURL = (url: string): string => {
   // If no subdomain is set or we're in localhost, return null
   if (
     !subdomain ||
+    // Happens when loading https://www.resilienceatlas.org
     subdomain === 'www' ||
-    subdomain.startsWith('localhost') ||
-    subdomain === 'staging'
+    // Happens when loading https://resilienceatlas.org
+    subdomain === 'resilienceatlas' ||
+    // Happens when loading https://staging.resilienceatlas.org
+    subdomain === 'staging' ||
+    // Happens when loading http://localhost:3000 (for example)
+    subdomain.startsWith('localhost')
   ) {
     return null;
   }


### PR DESCRIPTION
This PR fixes an issue that prevents the user from accessing the app via https://resilienceatlas.org.

The algorithm that determines the subdomain would read “resilienceatlas” and think this is a subdomain instead of the main domain. As a consequence, the user would be automatically redirected to the map.

## Testing instructions

1. Add the following lines to `/etc/hosts`:

```
127.0.0.1       resilienceatlas.org
127.0.0.1       www.resilienceatlas.org
127.0.0.1       madagascar.resilienceatlas.org
```

2. Build the app and start it: `yarn build && yarn start`
3. Open Chrome (not Firefox!) and go to http://www.resilienceatlas.org:3000/

The homepage must load.

4. Go to http://resilienceatlas.org:3000/

The homepage must load.

5. Go to http://madagascar.resilienceatlas.org:3000/

The map must load and the site scope correct (the main navigation will disappear).

## Tracking

Not tracked yet. Will add a task after we've deployed to production.
