### PR TITLE
Fix a crash when navigating the Madagascar journey

### DIFF
--- a/frontend/src/state/modules/layers/selectors.js
+++ b/frontend/src/state/modules/layers/selectors.js
@@ -48,10 +48,12 @@ export const makeActives = () =>
     (ids, layers, loaded, sourcesById) => {
       if (!loaded) return [];
       const activeLayers = denormalize(ids, [layer], { layers });
-      return activeLayers.map((layer) => ({
-        ...layer,
-        ...getSources(layer.attributions, sourcesById),
-      }));
+      return activeLayers
+        .filter((activeLayers) => !!activeLayers)
+        .map((layer) => ({
+          ...layer,
+          ...getSources(layer.attributions, sourcesById),
+        }));
     },
   );
 


### PR DESCRIPTION
This PR fixes an issue where the application would crash when navigating the Madagascar journey.

The map renders layers that belong to a specific site scope (Madascar's). As these layers are not correctly loaded in the application yet (will be addressed in [RA2-221](https://vizzuality.atlassian.net/browse/RA2-221)) the store doesn't contain the layers we're looking for. This leads to the creation of an array (`activeLayers`) that may contain `undefined` values that we then iterate over.

This PR simply filters the _falsy_ values out of the array. The root cause of this problem will be fixed in [RA2-221](https://vizzuality.atlassian.net/browse/RA2-221).

## Testing instructions

1. Open http://localhost:3000/journeys/8/step/1
2. Go to slide 4 (the first map) and wait until the map has fully loaded
3. Go to slide 6

The app must not crash and the user can reach the end of the journey.

## Tracking

[RA2-220](https://vizzuality.atlassian.net/browse/RA2-220)
