### PR TITLE
Load site_scope layers for embed

### DIFF
--- a/frontend/src/state/modules/layer_groups/actions.js
+++ b/frontend/src/state/modules/layer_groups/actions.js
@@ -21,15 +21,16 @@ export const openBatch = (ids = []) => ({
   ids,
 });
 
-export const load = (locale) =>
+export const load = (locale, siteScope) =>
   api(
     LOAD,
     ({ get }) =>
       get(URL_LAYER_GROUPS, {
-        params: { site_scope: subdomain, locale: toBackendLocale(locale) },
+        params: { site_scope: siteScope || subdomain, locale: toBackendLocale(locale) },
       }),
     {
       schema: [layer_group],
       locale,
+      subdomain: siteScope || subdomain,
     },
   );

--- a/frontend/src/state/modules/layer_groups/reducer.js
+++ b/frontend/src/state/modules/layer_groups/reducer.js
@@ -20,13 +20,14 @@ export default createReducer(initialState)({
     loading: true,
     error: null,
   }),
-  [LOAD.SUCCESS]: (state, { payload, meta: { locale } }) => {
+  [LOAD.SUCCESS]: (state, { payload, meta: { locale, subdomain } }) => {
     return {
       ...state,
       byId: payload.entities.layer_groups,
       all: payload.result,
       loaded: true,
       loadedLocale: locale,
+      loadedSubdomain: subdomain,
       loading: false,
     };
   },

--- a/frontend/src/state/modules/layers/actions.js
+++ b/frontend/src/state/modules/layers/actions.js
@@ -15,15 +15,18 @@ export const SET_OPACITY = 'layers / SET_OPACITY';
 export const SET_CHART_LIMIT = 'layers / SET_CHART_LIMIT';
 export const REORDER = 'layers / REORDER';
 
-export const load = (locale) =>
+export const load = (locale, siteScope) =>
   api(
     LOAD,
     ({ get }) =>
-      get(URL_LAYERS, { params: { site_scope: subdomain, locale: toBackendLocale(locale) } }),
+      get(URL_LAYERS, {
+        params: { site_scope: siteScope || subdomain, locale: toBackendLocale(locale) },
+      }),
     {
       schema: [layer],
       includedSchema: [source],
       locale,
+      subdomain: siteScope || subdomain,
     },
   );
 

--- a/frontend/src/state/modules/layers/reducer.js
+++ b/frontend/src/state/modules/layers/reducer.js
@@ -17,6 +17,7 @@ const initialState = {
   loading: false,
   loaded: false,
   loadedLocale: null,
+  loadedSubdomain: null,
   error: null,
 };
 
@@ -27,7 +28,7 @@ export default createReducer(initialState)({
     error: null,
   }),
 
-  [LOAD.SUCCESS]: (state, { payload, meta: { locale } }) => {
+  [LOAD.SUCCESS]: (state, { payload, meta: { locale, subdomain } }) => {
     const {
       entities: { layers },
       result,
@@ -51,6 +52,7 @@ export default createReducer(initialState)({
       loading: false,
       loaded: true,
       loadedLocale: locale,
+      loadedSubdomain: subdomain,
     };
   },
 

--- a/frontend/src/state/modules/layers/reducer.js
+++ b/frontend/src/state/modules/layers/reducer.js
@@ -1,4 +1,3 @@
-import { merge } from 'utilities';
 import { createReducer } from '../../utils';
 import { LOAD, SET_ACTIVES, TOGGLE, SET_OPACITY, REORDER, SET_CHART_LIMIT } from './actions';
 import { getPersistedLayers } from './utils';
@@ -46,7 +45,7 @@ export default createReducer(initialState)({
 
     return {
       ...state,
-      byId: merge(state.byId, layers),
+      byId: layers,
       all: payload.result,
       actives: [...actives],
       loading: false,

--- a/frontend/src/state/modules/layers/selectors.js
+++ b/frontend/src/state/modules/layers/selectors.js
@@ -85,6 +85,7 @@ export const getGrouped = () => {
     (published, groups, g_categories, g_subcategories, g_subgroups, g_defaultActive) => {
       const isActive = getActiveFromDefaults(g_defaultActive);
       if (!groups.length && !g_categories.length) {
+        // eslint-disable-next-line no-console
         console.info('There aren`t groups setted.');
         return groups;
       }

--- a/frontend/src/state/modules/layers/selectors.js
+++ b/frontend/src/state/modules/layers/selectors.js
@@ -49,7 +49,7 @@ export const makeActives = () =>
       if (!loaded) return [];
       const activeLayers = denormalize(ids, [layer], { layers });
       return activeLayers
-        .filter((activeLayers) => !!activeLayers)
+        .filter((activeLayer) => !!activeLayer)
         .map((layer) => ({
           ...layer,
           ...getSources(layer.attributions, sourcesById),

--- a/frontend/src/views/components/Journey/Embed/Embed.component.jsx
+++ b/frontend/src/views/components/Journey/Embed/Embed.component.jsx
@@ -75,9 +75,7 @@ const Embed = (props) => {
 
   const provideAbsoluteOrRelativeUrl = (url) => {
     if (url.startsWith('http')) {
-      return url
-        .replace(/(:\/\/)(?!www.)([^\/]+)/, `://www.$2`) // Temporary solution until redirects are fixed. Use regex to add www. to url
-        .replace('resilienceatlas.org/', `resilienceatlas.org/${locale}/`);
+      return url.replace('resilienceatlas.org/', `resilienceatlas.org/${locale}/`);
     }
     return `/${locale}${url}`;
   };

--- a/frontend/src/views/components/Journey/Embed/Embed.container.js
+++ b/frontend/src/views/components/Journey/Embed/Embed.container.js
@@ -14,6 +14,7 @@ const makeMapStateToProps = () => {
     countryName: state.journey.data.attributes.title,
     layersLoaded: state.layers.loaded,
     layersLocaleLoaded: state.layers.localeLoaded,
+    layersSubdomainLoaded: state.layers.subdomainLoaded,
   });
 
   return mapStateToProps;

--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -18,6 +18,7 @@ import { BASEMAPS, LABELS } from 'views/utils';
 
 import { LayerManagerContext } from 'views/contexts/layerManagerCtx';
 import { useRouterParams } from 'utilities';
+import { subdomain } from 'utilities/getSubdomain';
 import type { MAP_LABELS, BASEMAP_LABELS } from 'views/components/LayersList/Basemaps/constants';
 import type { NextRouter } from 'next/router';
 
@@ -44,8 +45,16 @@ const MapView = (props: MapViewProps) => {
     setMapLayerGroupsInteraction,
     setMapLayerGroupsInteractionLatLng,
     // data
-    layers: { loaded: layersLoaded, loadedLocale: layersLoadedLocale },
-    layer_groups: { loaded: layerGroupsLoaded, loadedLocale: layerGroupsLoadedLocale },
+    layers: {
+      loaded: layersLoaded,
+      loadedLocale: layersLoadedLocale,
+      loadedSubdomain: layersLoadedSubdomain,
+    },
+    layer_groups: {
+      loaded: layerGroupsLoaded,
+      loadedLocale: layerGroupsLoadedLocale,
+      loadedSubdomain: layerGroupsLoadedSubdomain,
+    },
     activeLayers,
     model_layer,
     defaultActiveGroups,
@@ -63,10 +72,22 @@ const MapView = (props: MapViewProps) => {
   const { query, locale } = router;
   const { setParam } = useRouterParams();
   const layerManagerRef = useContext(LayerManagerContext);
-
   useEffect(() => {
-    if (!layersLoaded || layersLoadedLocale !== locale) loadLayers(locale);
-    if (!layerGroupsLoaded || layerGroupsLoadedLocale !== locale) loadLayerGroups(locale);
+    const subdomainIsDifferentThanLoaded =
+      layersLoadedSubdomain !== subdomain && (layersLoadedSubdomain || subdomain);
+    if (!layersLoaded || layersLoadedLocale !== locale || subdomainIsDifferentThanLoaded) {
+      loadLayers(locale);
+    }
+    const layerGroupssubdomainIsDifferentThanLoaded =
+      layerGroupsLoadedSubdomain !== subdomain && (layerGroupsLoadedSubdomain || subdomain);
+
+    if (
+      !layerGroupsLoaded ||
+      layerGroupsLoadedLocale !== locale ||
+      layerGroupssubdomainIsDifferentThanLoaded
+    ) {
+      loadLayerGroups(locale);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locale]);
 

--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -88,8 +88,17 @@ const MapView = (props: MapViewProps) => {
     ) {
       loadLayerGroups(locale);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locale]);
+  }, [
+    layerGroupsLoaded,
+    layerGroupsLoadedLocale,
+    layerGroupsSubdomainIsDifferentThanLoaded,
+    layersLoaded,
+    layersLoadedLocale,
+    loadLayerGroups,
+    loadLayers,
+    locale,
+    subdomainIsDifferentThanLoaded,
+  ]);
 
   useEffect(() => {
     if (layersLoaded && layerGroupsLoaded && defaultActiveGroups.length) {

--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -72,19 +72,19 @@ const MapView = (props: MapViewProps) => {
   const { query, locale } = router;
   const { setParam } = useRouterParams();
   const layerManagerRef = useContext(LayerManagerContext);
+  const subdomainIsDifferentThanLoaded =
+    layersLoadedSubdomain !== subdomain && (layersLoadedSubdomain || subdomain);
+  const layerGroupsSubdomainIsDifferentThanLoaded =
+    layerGroupsLoadedSubdomain !== subdomain && (layerGroupsLoadedSubdomain || subdomain);
   useEffect(() => {
-    const subdomainIsDifferentThanLoaded =
-      layersLoadedSubdomain !== subdomain && (layersLoadedSubdomain || subdomain);
     if (!layersLoaded || layersLoadedLocale !== locale || subdomainIsDifferentThanLoaded) {
       loadLayers(locale);
     }
-    const layerGroupssubdomainIsDifferentThanLoaded =
-      layerGroupsLoadedSubdomain !== subdomain && (layerGroupsLoadedSubdomain || subdomain);
 
     if (
       !layerGroupsLoaded ||
       layerGroupsLoadedLocale !== locale ||
-      layerGroupssubdomainIsDifferentThanLoaded
+      layerGroupsSubdomainIsDifferentThanLoaded
     ) {
       loadLayerGroups(locale);
     }


### PR DESCRIPTION
Load correct number of site_scope layers in the legend for embed
    
- Temporary fix for embed url adding 'www.' so we can always see the embed for other subdomains
- Load layers from requested subdomain instead of the main domain layers
- Add attribute loadedSubdomain to reducers in layers and layerGroups to know when to load from correct domains and subdomains

## Testing instructions

Go to Madagascar journey:
http://localhost:3000/es/journeys/8/step/6

You should see two layers on the legend. Which is the number of the layers loaded.

I noticed that one layer was failing to load on the map. I guess this is a different issue


## Tracking

https://vizzuality.atlassian.net/browse/RA2-221?atlOrigin=eyJpIjoiYWQ3NzlmMjAzMDdhNDJiZDkxNDBhMTkzOWZkY2U0NzEiLCJwIjoiaiJ9
