### PR TITLE
Added public Cache-Control header

### DIFF
--- a/cloud_functions/titiler_cogs/titiler_cogs/app.py
+++ b/cloud_functions/titiler_cogs/titiler_cogs/app.py
@@ -1,6 +1,7 @@
 import logging
 from mangum import Mangum
 from titiler.core.factory import TilerFactory
+from titiler.core.middleware import CacheControlMiddleware
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 
 from fastapi import FastAPI, HTTPException, Query
@@ -28,6 +29,12 @@ app = FastAPI(title="Resilience COG tiler", description="Cloud Optimized GeoTIFF
 
 cog = TilerFactory()
 app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"])
+app.add_middleware(
+        CacheControlMiddleware,
+        cachecontrol="public",
+        cachecontrol_max_http_code=400, # https://github.com/developmentseed/titiler/pull/444
+        exclude_path={r"/healthz"},
+    )
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 

--- a/cloud_functions/titiler_cogs/titiler_cogs/app.py
+++ b/cloud_functions/titiler_cogs/titiler_cogs/app.py
@@ -31,7 +31,7 @@ cog = TilerFactory()
 app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"])
 app.add_middleware(
         CacheControlMiddleware,
-        cachecontrol="public",
+        cachecontrol="public, max-age=3600",
         cachecontrol_max_http_code=400, # https://github.com/developmentseed/titiler/pull/444
         exclude_path={r"/healthz"},
     )


### PR DESCRIPTION
An attempt to add caching headers using the available titiler middleware:
https://developmentseed.org/titiler/api/titiler/core/middleware/#cachecontrolmiddleware

## Testing instructions

- a request to /healthz returns no cache headers
- any other request returns public cache header

## Tracking

https://vizzuality.atlassian.net/browse/RA2-108
