### PR TITLE
Prevent crash if the center has a wrong format

### DIFF
--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -122,10 +122,17 @@ const MapView = (props: MapViewProps) => {
   }, [activeLayers]);
 
   const getCenter = useCallback(() => {
+    const DEFAULT_CENTER = { lat: 3.86, lng: 47.28 };
     if (query.center) {
       const decodeCenter = decodeURIComponent(query.center as string);
       if (decodeCenter && decodeCenter[0] === '{') {
-        return JSON.parse(decodeCenter);
+        try {
+          return JSON.parse(decodeCenter);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Error parsing center', decodeCenter, error);
+          return DEFAULT_CENTER;
+        }
       }
       const center = qs.parse(query.center);
       return center;
@@ -135,7 +142,7 @@ const MapView = (props: MapViewProps) => {
       return { lat: site.latitude, lng: site.longitude };
     }
 
-    return { lat: 3.86, lng: 47.28 };
+    return DEFAULT_CENTER;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [site.latitude, query.center]);
 


### PR DESCRIPTION
The problem here was that we have two center params on the embed map URL. I corrected that on staging back-office and it was working. 

Prevent the crash if the center format is incorrect and display an error with a default center
    
## Testing instructions

Go to madagascar journey last maps. On staging the url has been fixed. 

you can try this URL that has two center parameters (which has the problem initially)

http://localhost:3000/embed/map?layers=%5B%7B%22id%22%3A682%2C%22opacity%22%3A1%2C%22order%22%3Anull%7D%2C%7B%22id%22%3A9%2C%22opacity%22%3A1%2C%22order%22%3Anull%7D%5D&center=%7B%22lat%22%3A-17.654491233592395%2C%22lng%22%3A46.77978515624999%7D&center=%7B%22lat%22%3A-19.16592425362801%2C%22lng%22%3A44.67041015625%7D&zoom=6&site_scope=madagascar

## Tracking

https://vizzuality.atlassian.net/browse/RA2-241?atlOrigin=eyJpIjoiYzM0NjQ3NjQ2NWY1NDQ2NGI1NGE5NTc5NWMzNTI4ODQiLCJwIjoiaiJ9
