### PR TITLE
Get published attribute server side

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -58,7 +58,6 @@ const REACT_TOUR_OPTIONS: Omit<MapTourProviderProps, 'children'> = {
 export type ResilienceAppProps = {
   dehydratedState?: DehydratedState;
   translations: Translations;
-  published: boolean;
   setTranslations?: (translations: Translations) => {
     type: string;
     translations: Translations;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -58,6 +58,7 @@ const REACT_TOUR_OPTIONS: Omit<MapTourProviderProps, 'children'> = {
 export type ResilienceAppProps = {
   dehydratedState?: DehydratedState;
   translations: Translations;
+  published: boolean;
   setTranslations?: (translations: Translations) => {
     type: string;
     translations: Translations;
@@ -65,7 +66,15 @@ export type ResilienceAppProps = {
   dispatch?: (action: unknown) => void;
 };
 
+export type JourneyPageProps = ResilienceAppProps & {
+  published: boolean;
+};
+
 export type NextPageWithLayout<P = ResilienceAppProps, IP = P> = NextPage<P, IP> & {
+  Layout?: (page: ReactElement, translations: Translations) => ReactNode;
+};
+
+export type JourneyNextPageWithLayout<P = JourneyPageProps, IP = P> = NextPage<P, IP> & {
   Layout?: (page: ReactElement, translations: Translations) => ReactNode;
 };
 

--- a/frontend/src/pages/journeys/[id]/step/[step].tsx
+++ b/frontend/src/pages/journeys/[id]/step/[step].tsx
@@ -2,13 +2,19 @@ import { useEffect } from 'react';
 import Journey from 'views/components/Journey';
 import FullscreenLayout from 'views/layouts/fullscreen';
 import { getServerSideTranslations } from 'i18n';
-
+import { get } from 'state/utils/api';
+import { URL_JOURNEYS } from 'state/modules/journeys';
 import type { GetServerSidePropsContext } from 'next';
+import Head from 'next/head';
 
-import type { NextPageWithLayout } from '../../../_app';
+import type { JourneyNextPageWithLayout } from '../../../_app';
 import { useSetServerSideTranslations, withTranslations } from 'utilities/hooks/transifex';
 
-const JourneyDetailPage: NextPageWithLayout = ({ translations, setTranslations }) => {
+const JourneyDetailPage: JourneyNextPageWithLayout = ({
+  translations,
+  setTranslations,
+  published,
+}) => {
   useSetServerSideTranslations({ setTranslations, translations });
 
   useEffect(() => {
@@ -16,9 +22,14 @@ const JourneyDetailPage: NextPageWithLayout = ({ translations, setTranslations }
     setTranslations(translations);
   }, [setTranslations, translations]);
   return (
-    <div className="l-content">
-      <Journey />
-    </div>
+    <>
+      <Head>
+        {!published && <meta name="robots" content="noindex, nofollow, noimageindex, noarchive" />}
+      </Head>
+      <div className="l-content">
+        <Journey />
+      </div>
+    </>
   );
 };
 
@@ -30,9 +41,16 @@ export default withTranslations(JourneyDetailPage);
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { translations } = await getServerSideTranslations(context);
+
+  // We need to check if the journey is published server side
+  const { id } = context.query;
+  const result = await get(`${URL_JOURNEYS}/${id}`, {});
+  const { published } = result?.data?.data?.attributes || {};
+
   return {
     props: {
       translations,
+      published,
     },
   };
 }

--- a/frontend/src/state/modules/journeys/actions.js
+++ b/frontend/src/state/modules/journeys/actions.js
@@ -6,7 +6,7 @@ import { toBackendLocale } from 'utilities/helpers';
 export const LOAD = createApiAction('journeys/LOAD');
 export const LOAD_ONE = createApiAction('journeys/LOAD_ONE');
 
-const URL_JOURNEYS = '/journeys';
+export const URL_JOURNEYS = '/journeys';
 
 export const load = (locale) =>
   api(LOAD, ({ get }) => get(URL_JOURNEYS, { params: { locale: toBackendLocale(locale) } }), {

--- a/frontend/src/views/components/Journey/Journey.component.tsx
+++ b/frontend/src/views/components/Journey/Journey.component.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Loader from 'views/shared/Loader';
 import Landing from './Landing';
@@ -66,8 +65,7 @@ const Journey: FC<JourneyProps> = ({
 
   const journeyIds = journeysById && Object.keys(journeysById).map((id) => +id);
   const stepIndex = Number(step) - 1;
-  const { steps, attributes: journeyAttributes } = journey;
-  const { published } = journeyAttributes || {};
+  const { steps } = journey;
 
   if (!journeyLoaded || !journey || !steps[stepIndex]) return null;
   const stepInfo = steps[stepIndex];
@@ -75,33 +73,26 @@ const Journey: FC<JourneyProps> = ({
   const { attributes } = stepInfo;
   const { step_type: stepType } = attributes;
   return (
-    <>
-      <Head>
-        {published === false && (
-          <meta name="robots" content="noindex, nofollow, noimageindex, noarchive" />
-        )}
-      </Head>
-      <div className="l-journey" id="journeyIndexView">
-        <Loader loading={journeyLoading} />
+    <div className="l-journey" id="journeyIndexView">
+      <Loader loading={journeyLoading} />
 
-        {journeyLoaded &&
-          React.createElement(JOURNEY_TYPES[stepType], {
-            ...attributes,
-            translations,
-            isLastStep: stepIndex === steps.length - 1,
-          })}
+      {journeyLoaded &&
+        React.createElement(JOURNEY_TYPES[stepType], {
+          ...attributes,
+          translations,
+          isLastStep: stepIndex === steps.length - 1,
+        })}
 
-        <Controls journeyIds={journeyIds} slideslength={steps.length} />
+      <Controls journeyIds={journeyIds} slideslength={steps.length} />
 
-        {!journeyLoading && stepType !== 'embed' && (
-          <p className={`credits ${stepType}`}>
-            <a target="_blank" rel="noopener noreferrer" href={attributes.credits_url}>
-              {attributes.credits}
-            </a>
-          </p>
-        )}
-      </div>
-    </>
+      {!journeyLoading && stepType !== 'embed' && (
+        <p className={`credits ${stepType}`}>
+          <a target="_blank" rel="noopener noreferrer" href={attributes.credits_url}>
+            {attributes.credits}
+          </a>
+        </p>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
We needed to get the published attribute server side so the noindex meta tag will be always rendered and the bots will get it and don't index the unpublished journeys.

## Testing instructions

Use the rich results page. The page shouldn’t be indexed https://search.google.com/test/rich-results/r

## Tracking

https://vizzuality.atlassian.net/browse/RA2-161?atlOrigin=eyJpIjoiNjQ5Y2Y5NGI5NTFkNGI4NWEwZmJmNWIxOTUzY2U2MzgiLCJwIjoiaiJ9