### PR TITLE
Dont redirect app. Test and relocate unit tests

### DIFF
--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
     '*.localhost': '127.0.0.1',
   },
   e2e: {
+    specPattern: '**/*.cy.js',
     baseUrl: 'http://localhost:3000',
     screenshotOnRunFailure: true,
     video: false,

--- a/frontend/cypress/integration/unit.cy.js
+++ b/frontend/cypress/integration/unit.cy.js
@@ -1,0 +1,59 @@
+import { absoluteOrRelativeUrlWithCurrentLocale } from '../../src/utilities/helpers';
+import { getSubdomainFromURL } from '../../src/utilities/getSubdomain';
+
+describe('absoluteOrRelativeUrlWithCurrentLocale', function () {
+  const locales = ['en', 'es', 'fr', 'pt_BR', 'zh_CN', 'ru'];
+  const locale = 'es';
+  it('returns the correct url', function () {
+    expect(
+      absoluteOrRelativeUrlWithCurrentLocale(
+        'https://www.resilienceatlas.com/en/embed?whatever',
+        locale,
+        locales,
+      ),
+    ).to.eq('https://www.resilienceatlas.com/es/embed?whatever');
+
+    expect(
+      absoluteOrRelativeUrlWithCurrentLocale(
+        'http://locahost:3000/embed?whatever',
+        locale,
+        locales,
+      ),
+    ).to.eq('http://locahost:3000/es/embed?whatever');
+
+    expect(absoluteOrRelativeUrlWithCurrentLocale('/embed?whatever', locale, locales)).to.eq(
+      '/es/embed?whatever',
+    );
+
+    expect(absoluteOrRelativeUrlWithCurrentLocale('/en/embed?whatever', locale, locales)).to.eq(
+      '/es/embed?whatever',
+    );
+    expect(
+      absoluteOrRelativeUrlWithCurrentLocale(
+        'http://localhost:3000/en/map?tab=layers&layers=%center%es%22',
+        locale,
+        locales,
+      ),
+    ).to.eq('http://localhost:3000/es/map?tab=layers&layers=%center%es%22');
+    expect(
+      absoluteOrRelativeUrlWithCurrentLocale(
+        'https://staging.resilienceatlas.org/embed/map?tab=layers&layers=...',
+        locale,
+        locales,
+      ),
+    ).to.eq('https://staging.resilienceatlas.org/es/embed/map?tab=layers&layers=...');
+  });
+});
+
+describe('getSubdomainFromURL', function () {
+  it('returns the correct subdomain', function () {
+    expect(getSubdomainFromURL('https://www.resilienceatlas.com/en/embed?whatever')).to.eq(null);
+    expect(getSubdomainFromURL('https://resilienceatlas.com/en/embed?whatever')).to.eq(null);
+    expect(getSubdomainFromURL('https://staging.resilienceatlas.org/embed/map')).to.eq(null);
+    expect(getSubdomainFromURL('https://app.resilienceatlas.org/embed/map')).to.eq(null);
+    expect(getSubdomainFromURL('https://localhost:3000/embed/map')).to.eq(null);
+    expect(getSubdomainFromURL('https://madagascar.resilienceatlas.org/embed/map')).to.eq(
+      'madagascar',
+    );
+  });
+});

--- a/frontend/src/state/utils/api.ts
+++ b/frontend/src/state/utils/api.ts
@@ -5,8 +5,6 @@ import type { schema } from 'normalizr';
 
 import { merge } from 'utilities/helpers';
 
-export const isProd = process.env.NODE_ENV === 'production';
-
 export const PORT = process.env.NEXT_PUBLIC_API_HOST;
 
 const defaultConfig = {

--- a/frontend/src/utilities/getSubdomain.ts
+++ b/frontend/src/utilities/getSubdomain.ts
@@ -1,5 +1,6 @@
-import { isProd } from '../state/utils/api';
 import { getRouterParam } from './routeParams';
+
+const isProd = process.env.NODE_ENV === 'production';
 
 export const getSubdomainFromURL = (url: string): string => {
   // Site scope depends on the domain set in the API
@@ -14,6 +15,8 @@ export const getSubdomainFromURL = (url: string): string => {
     subdomain === 'resilienceatlas' ||
     // Happens when loading https://staging.resilienceatlas.org
     subdomain === 'staging' ||
+    // Happens when loading https://app.resilienceatlas.org
+    subdomain === 'app' ||
     // Happens when loading http://localhost:3000 (for example)
     subdomain.startsWith('localhost')
   ) {


### PR DESCRIPTION
We dont want to redirect app subdomains to  the map page. 

Also created some unit tests for the getSubdomainFromURL function and moved the unit tests to the appropiate folder.

Note: isProd was only used on this files so I moved it there and removed the export

## Testing instructions

When deployed test app.resilienceatlas.com 
it shouldnt redirect to map

## Tracking

https://vizzuality.atlassian.net/browse/RA2-48?atlOrigin=eyJpIjoiNDhiM2Q1YmQ4MjNhNDIyYjliZDU4Y2Q1NmNkMjQxMWIiLCJwIjoiaiJ9