### PR TITLE
Fix visual conflict between the privacy notice and the map tour

### DIFF
--- a/frontend/src/views/styles/modules/_m-map-tour.scss
+++ b/frontend/src/views/styles/modules/_m-map-tour.scss
@@ -36,3 +36,7 @@
     }
   }
 }
+
+.map-tour-mask {
+  z-index: 999 !important;
+}

--- a/frontend/src/views/styles/modules/_m-privacy-banner.scss
+++ b/frontend/src/views/styles/modules/_m-privacy-banner.scss
@@ -1,39 +1,37 @@
 .m-privacy-banner {
   margin: 0 auto;
-  padding: 0 rem($content-margin);
+  padding: rem($content-margin);
 
   position: fixed;
   bottom: 0;
   left: 0;
   z-index: 1000;
   width: 100%;
+  max-width: 430px;
   animation: slide-up 0.5s ease-in;
   overflow: hidden;
-  background-color: $gray-6;
+  background-color: rgba($black, 0.76);
   outline: none;
-  display: flex;
   justify-content: space-between;
 
   .disclaimer {
-    max-width: 70%;
-    font-size: rem(14px);
+    margin: 0 0 28px 0;
+    font-size: rem(12px);
     line-height: rem(16px);
-    color: $black-charcoal;
+    font-weight: 700;
+    color: $white;
 
     .link {
       text-decoration: underline;
-      color: $black-charcoal;
+      color: $white;
     }
   }
 
   .buttons {
     display: flex;
     align-items: center;
-    justify-content: center;
-
-    .btn {
-      margin-left: 5px;
-    }
+    justify-content: start;
+    gap: 5px;
   }
 }
 


### PR DESCRIPTION
This PR updates the styles of the privacy notice so that it is not displayed on top of the step 2 (legend) of the map tour.

## Testing instructions

1. Clean your cookies and local storage
2. Go directly to the map

The privacy notice must be displayed on the left (not over the legend) and the user must be able to accept/reject cookies while the map tour is still active.

## Tracking

[RA2-246](https://vizzuality.atlassian.net/browse/RA2-246)
