### PR TITLE
Dont show hide and remove buttons on embed

### DIFF
--- a/frontend/src/views/components/Journey/Embed/Embed.component.jsx
+++ b/frontend/src/views/components/Journey/Embed/Embed.component.jsx
@@ -133,7 +133,7 @@ const Embed = (props) => {
               {content && <DangerousHTML html={content} className="content" />}
             </section>
             {source}
-            <Legend defaultEmbedURLLayerParams={getLayerData(mapUrl)} />
+            <Legend isEmbed defaultEmbedURLLayerParams={getLayerData(mapUrl)} />
             <InfoWindow />
             <footer>
               <p>

--- a/frontend/src/views/components/Legend/Legend.component.jsx
+++ b/frontend/src/views/components/Legend/Legend.component.jsx
@@ -17,6 +17,7 @@ const Legend = ({
   toggleLayer,
   setOpacity,
   defaultEmbedURLLayerParams,
+  isEmbed,
 }) => {
   const [opened, toggleOpen] = useToggle(true);
   const onDragEnd = useCallback(
@@ -91,31 +92,36 @@ const Legend = ({
                                       </svg>
                                     </button>
 
-                                    <button
-                                      type="button"
-                                      className={cx('btn-action', 'btn-visibility')}
-                                      {...clickable(() => setOpacity(id, layerVisible ? 0 : 1))}
-                                      data-id={id}
-                                    >
-                                      <svg>
-                                        <use
-                                          xlinkHref={`#icon-visibility${
-                                            layerVisible ? 'on' : 'off'
-                                          }`}
-                                        />
-                                      </svg>
-                                    </button>
+                                    {!isEmbed && (
+                                      <button
+                                        type="button"
+                                        className={cx('btn-action', 'btn-visibility')}
+                                        {...clickable(() => setOpacity(id, layerVisible ? 0 : 1))}
+                                        data-id={id}
+                                      >
+                                        {' '}
+                                        <svg>
+                                          <use
+                                            xlinkHref={`#icon-visibility${
+                                              layerVisible ? 'on' : 'off'
+                                            }`}
+                                          />
+                                        </svg>
+                                      </button>
+                                    )}
 
-                                    <button
-                                      type="button"
-                                      className="btn-remove"
-                                      {...clickable(() => toggleLayer(id))}
-                                      data-layer-id={id}
-                                    >
-                                      <svg className="icon">
-                                        <use xlinkHref="#icon-remove" />
-                                      </svg>
-                                    </button>
+                                    {!isEmbed && (
+                                      <button
+                                        type="button"
+                                        className="btn-remove"
+                                        {...clickable(() => toggleLayer(id))}
+                                        data-layer-id={id}
+                                      >
+                                        <svg className="icon">
+                                          <use xlinkHref="#icon-remove" />
+                                        </svg>
+                                      </button>
+                                    )}
                                   </div>
                                 )}
                               </header>


### PR DESCRIPTION
Remove hide and delete layer buttons on embed legend

## Testing instructions

Go to any Journeys map. You shouldn't see the hide and delete layer buttons on the legend

## Tracking

https://vizzuality.atlassian.net/browse/RA2-248?atlOrigin=eyJpIjoiMzcxNzQzM2U2NDU3NDNhYWI1Y2FhNmJjZWNjM2JhNGUiLCJwIjoiaiJ9
