### PR TITLE
Fix/RA2-247-layer-order

### DIFF
--- a/frontend/src/state/schema.js
+++ b/frontend/src/state/schema.js
@@ -121,7 +121,8 @@ export const layer = new schema.Entity(
         interactivity: l.attributes.interactivity,
         sql: l.attributes.query,
         color: l.attributes.color,
-        opacity: l.attributes.opacity,
+        // Opacity should start with 1 if it's missing
+        opacity: l.attributes.opacity === null ? 1 : l.attributes.opacity,
         no_opacity: l.attributes.opacity === 0,
         order: l.attributes.order || null,
         maxZoom: l.attributes.zoom_max || 100,

--- a/frontend/src/views/components/Journey/Embed/Embed.container.js
+++ b/frontend/src/views/components/Journey/Embed/Embed.container.js
@@ -1,14 +1,19 @@
 import { connect } from 'react-redux';
 
-import { load as loadLayers, setActives as setActiveLayer } from 'state/modules/layers';
-
+import {
+  load as loadLayers,
+  setActives as setActiveLayer,
+  makeActives,
+} from 'state/modules/layers';
 import JourneyEmbed from './Embed.component';
 
 const makeMapStateToProps = () => {
+  const getActives = makeActives();
+
   const mapStateToProps = (state) => ({
     countryName: state.journey.data.attributes.title,
     layersLoaded: state.layers.loaded,
-    layersById: state.layers.byId,
+    activeLayers: getActives(state),
     layersLocaleLoaded: state.layers.localeLoaded,
     layersSubdomainLoaded: state.layers.subdomainLoaded,
   });

--- a/frontend/src/views/components/Legend/Legend.component.jsx
+++ b/frontend/src/views/components/Legend/Legend.component.jsx
@@ -8,7 +8,7 @@ import { sortBy, useToggle, clickable } from 'utilities';
 import LegendItem from './LegendItem';
 import LegendTimeline from './LegendTimeline';
 
-const byOrder = sortBy('order', 'DESC');
+const byOrder = sortBy('order', true);
 
 const Legend = ({
   activeLayers,

--- a/frontend/src/views/components/Legend/Legend.component.jsx
+++ b/frontend/src/views/components/Legend/Legend.component.jsx
@@ -4,11 +4,9 @@ import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import Loader from 'views/shared/Loader';
 import InfoWindow from 'views/components/InfoWindow';
 import { T } from '@transifex/react';
-import { sortBy, useToggle, clickable } from 'utilities';
+import { useToggle, clickable } from 'utilities';
 import LegendItem from './LegendItem';
 import LegendTimeline from './LegendTimeline';
-
-const byOrder = sortBy('order', true);
 
 const Legend = ({
   activeLayers,
@@ -41,122 +39,118 @@ const Legend = ({
                 <Loader loading={loading} />
 
                 <ul {...droppableProps} ref={innerRef} className="m-legend__list">
-                  {activeLayers
-                    .filter(Boolean)
-                    .sort(byOrder)
-                    .map((layer, index) => {
-                      const { id, name, notAvailableByZoom, legend, info, timeline } = layer;
+                  {activeLayers.filter(Boolean).map((layer, index) => {
+                    const { id, name, notAvailableByZoom, legend, info, timeline } = layer;
 
-                      const defaultParams = defaultEmbedURLLayerParams?.find(
-                        (l) => l.id === layer.id,
-                      );
-                      const date = layer.date || defaultParams?.date;
-                      const opacity = layer.opacity || defaultParams?.opacity;
+                    const defaultParams = defaultEmbedURLLayerParams?.find(
+                      (l) => l.id === layer.id,
+                    );
+                    const date = layer.date || defaultParams?.date;
+                    const opacity = layer.opacity || defaultParams?.opacity;
 
-                      const { source, link } = info || {};
-                      const layerVisible = opacity > 0;
+                    const { source, link } = info || {};
+                    const layerVisible = opacity > 0;
 
-                      return (
-                        <Draggable key={id} draggableId={id} index={index}>
-                          {({ draggableProps, dragHandleProps, innerRef: dragRef }) => (
-                            <li
-                              className={cx('drag-items', {
-                                'is-not-available-by-zoom': notAvailableByZoom,
-                              })}
-                              data-id={id}
-                              ref={dragRef}
-                              {...draggableProps}
-                              {...dragHandleProps}
-                            >
-                              <header>
-                                <span className="draggable-icon">
-                                  <svg>
-                                    <use xlinkHref="#icon-drag" />
-                                  </svg>
-                                </span>
+                    return (
+                      <Draggable key={id} draggableId={id} index={index}>
+                        {({ draggableProps, dragHandleProps, innerRef: dragRef }) => (
+                          <li
+                            className={cx('drag-items', {
+                              'is-not-available-by-zoom': notAvailableByZoom,
+                            })}
+                            data-id={id}
+                            ref={dragRef}
+                            {...draggableProps}
+                            {...dragHandleProps}
+                          >
+                            <header>
+                              <span className="draggable-icon">
+                                <svg>
+                                  <use xlinkHref="#icon-drag" />
+                                </svg>
+                              </span>
 
-                                <h3>{name}</h3>
+                              <h3>{name}</h3>
 
-                                {id !== -1 && (
-                                  <div className="actions">
+                              {id !== -1 && (
+                                <div className="actions">
+                                  <button
+                                    type="button"
+                                    className="btn-info"
+                                    {...clickable(() => {
+                                      InfoWindow.show(name, info);
+                                    })}
+                                    data-layer-id={id}
+                                  >
+                                    <svg className="icon">
+                                      <use xlinkHref="#icon-info" />
+                                    </svg>
+                                  </button>
+
+                                  {!isEmbed && (
                                     <button
                                       type="button"
-                                      className="btn-info"
-                                      {...clickable(() => {
-                                        InfoWindow.show(name, info);
-                                      })}
+                                      className={cx('btn-action', 'btn-visibility')}
+                                      {...clickable(() => setOpacity(id, layerVisible ? 0 : 1))}
+                                      data-id={id}
+                                    >
+                                      <svg>
+                                        <use
+                                          xlinkHref={`#icon-visibility${
+                                            layerVisible ? 'on' : 'off'
+                                          }`}
+                                        />
+                                      </svg>
+                                    </button>
+                                  )}
+
+                                  {!isEmbed && (
+                                    <button
+                                      type="button"
+                                      className="btn-remove"
+                                      {...clickable(() => toggleLayer(id))}
                                       data-layer-id={id}
                                     >
                                       <svg className="icon">
-                                        <use xlinkHref="#icon-info" />
+                                        <use xlinkHref="#icon-remove" />
                                       </svg>
                                     </button>
-
-                                    {!isEmbed && (
-                                      <button
-                                        type="button"
-                                        className={cx('btn-action', 'btn-visibility')}
-                                        {...clickable(() => setOpacity(id, layerVisible ? 0 : 1))}
-                                        data-id={id}
-                                      >
-                                        {' '}
-                                        <svg>
-                                          <use
-                                            xlinkHref={`#icon-visibility${
-                                              layerVisible ? 'on' : 'off'
-                                            }`}
-                                          />
-                                        </svg>
-                                      </button>
-                                    )}
-
-                                    {!isEmbed && (
-                                      <button
-                                        type="button"
-                                        className="btn-remove"
-                                        {...clickable(() => toggleLayer(id))}
-                                        data-layer-id={id}
-                                      >
-                                        <svg className="icon">
-                                          <use xlinkHref="#icon-remove" />
-                                        </svg>
-                                      </button>
-                                    )}
-                                  </div>
-                                )}
-                              </header>
-                              <LegendItem legend={legend} layer={layer} />
-                              {source && (
-                                <div className="source-container">
-                                  <div className="source">
-                                    <span className="source-bold">
-                                      <T _str="Source:" />{' '}
-                                    </span>
-                                    <span>{source}</span>
-                                  </div>
-                                  <a
-                                    className="source-link"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    href={link}
-                                  >
-                                    {link}
-                                  </a>
+                                  )}
                                 </div>
                               )}
-                              {timeline && (
-                                <LegendTimeline
-                                  selectedDate={date}
-                                  layerId={id}
-                                  layerName={name}
-                                  timeline={timeline}
-                                />
-                              )}
-                            </li>
-                          )}
-                        </Draggable>
-                      );
-                    })}
+                            </header>
+                            <LegendItem legend={legend} layer={layer} />
+                            {source && (
+                              <div className="source-container">
+                                <div className="source">
+                                  <span className="source-bold">
+                                    <T _str="Source:" />{' '}
+                                  </span>
+                                  <span>{source}</span>
+                                </div>
+                                <a
+                                  className="source-link"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  href={link}
+                                >
+                                  {link}
+                                </a>
+                              </div>
+                            )}
+                            {timeline && (
+                              <LegendTimeline
+                                selectedDate={date}
+                                layerId={id}
+                                layerName={name}
+                                timeline={timeline}
+                              />
+                            )}
+                          </li>
+                        )}
+                      </Draggable>
+                    );
+                  })}
                   {placeholder}
                 </ul>
               </div>

--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -3,7 +3,7 @@ import 'leaflet.pm';
 import 'leaflet-active-area';
 // UTFGrid library requires corslite, only included in the minimized version
 import 'leaflet-utfgrid/L.UTFGrid-min';
-
+import { sortBy, useRouterParams } from 'utilities';
 import React, { useCallback, useEffect, useContext } from 'react';
 import qs from 'qs';
 import omit from 'lodash/omit';
@@ -18,9 +18,7 @@ import { BASEMAPS, LABELS } from 'views/utils';
 import { URL_PERSISTED_KEYS } from 'state/modules/layers/utils';
 
 import { LayerManagerContext } from 'views/contexts/layerManagerCtx';
-import { useRouterParams } from 'utilities';
 import { subdomain } from 'utilities/getSubdomain';
-
 import Toolbar from './Toolbar';
 import DrawingManager from './DrawingManager';
 import MapOffset from './MapOffset';
@@ -110,6 +108,9 @@ const MapView = (props: MapViewProps) => {
     onLayerLoading(false);
   }, [onLayerLoading]);
 
+  const byOrder = (a: number, b: number) => sortBy('order', true)(a, b);
+  const MAX_LAYER_Z_INDEX = 1000;
+
   return (
     <Maps
       customClass="m-map"
@@ -158,12 +159,13 @@ const MapView = (props: MapViewProps) => {
       {(map) => (
         <>
           {tab === TABS.LAYERS &&
-            activeLayers.map((l) => (
+            activeLayers.sort(byOrder).map((l, index) => (
               <LayerManager map={map} plugin={PluginLeaflet} ref={layerManagerRef} key={l.id}>
                 <Layer
                   {...omit(l, 'interactivity')}
                   slug={l.slug || l.id}
                   key={l.id}
+                  zIndex={MAX_LAYER_Z_INDEX - index}
                   // Interaction
                   {...(!!l.interactionConfig &&
                     !!l.interactionConfig &&

--- a/frontend/src/views/components/Map/Map.component.tsx
+++ b/frontend/src/views/components/Map/Map.component.tsx
@@ -3,7 +3,7 @@ import 'leaflet.pm';
 import 'leaflet-active-area';
 // UTFGrid library requires corslite, only included in the minimized version
 import 'leaflet-utfgrid/L.UTFGrid-min';
-import { sortBy, useRouterParams } from 'utilities';
+import { useRouterParams } from 'utilities';
 import React, { useCallback, useEffect, useContext } from 'react';
 import qs from 'qs';
 import omit from 'lodash/omit';
@@ -108,7 +108,6 @@ const MapView = (props: MapViewProps) => {
     onLayerLoading(false);
   }, [onLayerLoading]);
 
-  const byOrder = (a: number, b: number) => sortBy('order', true)(a, b);
   const MAX_LAYER_Z_INDEX = 1000;
 
   return (
@@ -159,7 +158,7 @@ const MapView = (props: MapViewProps) => {
       {(map) => (
         <>
           {tab === TABS.LAYERS &&
-            activeLayers.sort(byOrder).map((l, index) => (
+            activeLayers.map((l, index) => (
               <LayerManager map={map} plugin={PluginLeaflet} ref={layerManagerRef} key={l.id}>
                 <Layer
                   {...omit(l, 'interactivity')}


### PR DESCRIPTION
Fix layer ordering in the legend of the map and embed
Fix reordering on drag and drop

Test layers with opacity null now show as visible at first on the map

## Testing instructions

Go to the map: You should see any layers on the same order on the map than on the legend. Also you should be able to reorder them.

The same for the journeys embed.

https://localhost:3000/journeys/7/step/6

https://localhost:3000/map?layers=%5B%7B%22id%22%3A96%2C%22opacity%22%3A1%2C%22order%22%3A2%7D%2C%7B%22id%22%3A212%2C%22opacity%22%3A1%2C%22order%22%3A1%7D%5D&zoom=4&center=%7B%22lat%22%3A0.4833927027896987%2C%22lng%22%3A6.943359374999999%7D&tab=layers

## Tracking

https://vizzuality.atlassian.net/browse/RA2-247?atlOrigin=eyJpIjoiZTMxMDI1YjEwNzRlNGQyYzlmODQzMGQxODJmYzBjOWYiLCJwIjoiaiJ9