### PR TITLE
Feature/RA2-249-continuous-layers-axis-labels

### DIFF
--- a/frontend/src/views/shared/Widgets/WidgetBarChart.jsx
+++ b/frontend/src/views/shared/Widgets/WidgetBarChart.jsx
@@ -39,7 +39,15 @@ export const WidgetBarChart = ({
     { slug, geojson },
     { type, analysisQuery, analysisBody },
   );
-  const { unit: singleUnit, units, bar_color } = useMemo(() => JSON.parse(legend), [legend]);
+  const { unit: singleUnit, units, bar_color } = useMemo(() => {
+    try {
+      return JSON.parse(legend);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Json parse failed', e)
+      return {};
+    }
+  }, [legend]);
   const unit = singleUnit || units;
   const isCOG = useMemo(() => type === 'cog', [type]);
   const mergedBarData = useMemo(() => {

--- a/frontend/src/views/shared/Widgets/WidgetBarChart.jsx
+++ b/frontend/src/views/shared/Widgets/WidgetBarChart.jsx
@@ -1,9 +1,18 @@
 import dynamic from 'next/dynamic';
 import React, { useMemo } from 'react';
-import { ResponsiveContainer, BarChart, XAxis, YAxis, CartesianGrid, Bar, Tooltip } from 'recharts';
+import {
+  ResponsiveContainer,
+  BarChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Bar,
+  Tooltip,
+  Label,
+} from 'recharts';
 
 import InfoWindow from 'views/components/InfoWindow';
-import { T } from '@transifex/react';
+import { T, useT } from '@transifex/react';
 
 import { useWidget, formatNumber } from 'utilities';
 import { CustomTooltip } from './CustomTooltip';
@@ -25,13 +34,14 @@ export const WidgetBarChart = ({
   geojson,
   type,
 }) => {
+  const t = useT();
   const { rootWidgetProps, loaded, data, noData } = useWidget(
     { slug, geojson },
     { type, analysisQuery, analysisBody },
   );
-  const { unit, bar_color } = useMemo(() => JSON.parse(legend), [legend]);
+  const { unit: singleUnit, units, bar_color } = useMemo(() => JSON.parse(legend), [legend]);
+  const unit = singleUnit || units;
   const isCOG = useMemo(() => type === 'cog', [type]);
-
   const mergedBarData = useMemo(() => {
     return isCOG
       ? data?.rows
@@ -86,7 +96,21 @@ export const WidgetBarChart = ({
                   }
                   textAnchor="end"
                   tickLine={false}
-                />
+                >
+                  <Label
+                    value={t(
+                      `${
+                        unit || t('Value', { comment: 'Value bins in continuous bar chart' })
+                      } bins`,
+                      {
+                        comment: '{unit} bins in continuous bar chart',
+                      },
+                    )}
+                    position="bottom"
+                    offset={36}
+                    className="xAxisLabel"
+                  />
+                </XAxis>
                 <YAxis
                   allowDataOverflow
                   axisLine={false}
@@ -102,7 +126,16 @@ export const WidgetBarChart = ({
                   unit={unit}
                   tick={{ ...tickOptions }}
                   padding={{ right: 20 }}
-                />
+                >
+                  <Label
+                    value={t('Frequency', {
+                      comment: 'Frequency of values in continuous bar chart',
+                    })}
+                    position="insideTopLeft"
+                    offset={-26}
+                    className="yAxisLabel"
+                  />
+                </YAxis>
 
                 <Tooltip
                   content={<CustomTooltip unit={unit} minimumFractionDigits={isCOG && 0} />}

--- a/frontend/src/views/shared/Widgets/text-chart/component.tsx
+++ b/frontend/src/views/shared/Widgets/text-chart/component.tsx
@@ -34,7 +34,7 @@ export const TextChart: FC<TextChartProps> = ({
       if (typeof value === 'number') {
         value = value.toFixed(2);
       }
-
+      if (!value) return null;
       return res.replace(`{{${key}}}`, `<strong>${value}</strong>`);
     }, analysisTextTemplate);
   }, [data, analysisTextTemplate]);
@@ -44,7 +44,7 @@ export const TextChart: FC<TextChartProps> = ({
       <div className="name">{name}</div>
       {loaded && (
         <>
-          {noData && (
+          {(noData || !sentence) && (
             <div className="widget-no-data">
               <h3>
                 <T _str="NO DATA AVAILABLE" />

--- a/frontend/src/views/styles/modules/_m-widget.scss
+++ b/frontend/src/views/styles/modules/_m-widget.scss
@@ -98,6 +98,18 @@
     fill: $gray-medium;
   }
 
+  .yAxisLabel {
+    font-size: rem(13px);
+    transform: translateX(80px);
+    text-anchor: end;
+    fill: $gray-medium;
+  }
+
+  .xAxisLabel {
+    font-size: rem(13px);
+    fill: $gray-medium;
+  }
+
   .widget-no-data {
     display: flex;
     align-items: center;


### PR DESCRIPTION
- Add labels on axis of continuous layer charts in analysis: 'Frequency' for y axis and '{{ unit || 'Value'}} bins' in x axis
<img width="474" alt="image" src="https://github.com/ConservationInternational/resilienceatlas/assets/9701591/2b881d66-a393-4041-8c93-ba4e213d1436">

Also, fix text widget when we don't have data. It was showing some sentence with null in it before.

<img width="445" alt="image" src="https://github.com/ConservationInternational/resilienceatlas/assets/9701591/b5d32f09-b472-490d-8f84-d2ffa072a6a5">

## Testing instructions
Go to the following layers, and analyze some place. You should get the following labels:

Map test layersis → test cog [temporal]

x axis: “tons bins”

y axis:  “Frequency”

Map test layers → wheat [continous cog]

x axis: “tons bins”

y axis: “Frequency”

Stressors and Shocks → Marine → Marine plastic

x axis: “g/km2 bins”

y axis: “Frequency”

Stressors and Shocks → Marine → Sea Level Rise → Sea Level Rise (2016)

x axis: “Value bins”

y axis: “Frequency”

## Tracking

https://vizzuality.atlassian.net/browse/RA2-249?atlOrigin=eyJpIjoiN2EwYmQ5MjBjYTI5NDRjYmI3Y2VjZDE2ZTdmNTk4NzEiLCJwIjoiaiJ9