### PR TITLE
Fix XYZ Tileset layer display

### DIFF
--- a/frontend/.gitconfig
+++ b/frontend/.gitconfig
@@ -1,0 +1,2 @@
+[url "https://github.com/"]
+  insteadOf = ssh://git@github.com/

--- a/frontend/.gitconfig
+++ b/frontend/.gitconfig
@@ -1,2 +1,0 @@
-[url "https://github.com/"]
-  insteadOf = ssh://git@github.com/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "redux-form": "^8.2.3",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "resilience-layer-manager": "https://github.com/ConservationInternational/resilienceatlas-layermanager.git#1.0.4",
+    "resilience-layer-manager": "github:ConservationInternational/resilienceatlas-layermanager#1.0.4",
     "sass": "^1.58.3",
     "slick-carousel": "^1.8.1",
     "use-debounce": "^9.0.4",

--- a/frontend/src/state/schema.js
+++ b/frontend/src/state/schema.js
@@ -86,7 +86,7 @@ export const layer = new schema.Entity(
         'xyz tileset': {
           type: 'tileLayer',
           body: {
-            url: l.attributes.query,
+            url: layerConfig?.body?.url,
           },
         },
         gee: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5326,9 +5326,9 @@ reselect@^4.0.0:
   resolved "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz"
   integrity sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==
 
-"resilience-layer-manager@https://github.com/ConservationInternational/resilienceatlas-layermanager.git#1.0.4":
+"resilience-layer-manager@github:ConservationInternational/resilienceatlas-layermanager#1.0.4":
   version "1.0.4"
-  resolved "git+ssh://git@github.com/ConservationInternational/resilienceatlas-layermanager.git#71310fb9e4a5da227e754cfb8e29b74a4b4e35de"
+  resolved "https://codeload.github.com/ConservationInternational/resilienceatlas-layermanager/tar.gz/71310fb9e4a5da227e754cfb8e29b74a4b4e35de"
   dependencies:
     axios "^0.18.0"
     lodash "^4.17.11"


### PR DESCRIPTION
Fix XYZ Tileset layer display that incorrectly uses the attribute returned from the API. 

Additionally, an update to the packages.json is required to correctly build/test the app since [GitHub has changed](https://github.blog/2021-09-01-improving-git-protocol-security-github/) how the packages should be used.

## Testing instructions

Create a new XYZ Tileset layer in the Admin UI. Select this layer to load onto a map. This would never load. This update should now use the correct attribute set in the API/Admin.

## Tracking

Issue: #226 

